### PR TITLE
Support net8.0 and net9.0; various project updates

### DIFF
--- a/src/RForge/RForge.Abstractions/RForge.Abstractions.csproj
+++ b/src/RForge/RForge.Abstractions/RForge.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <Description>Placeholder</Description>

--- a/src/RForge/RForge.Blazor.UnitTest/RForge.Blazor.UnitTest.csproj
+++ b/src/RForge/RForge.Blazor.UnitTest/RForge.Blazor.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/src/RForge/RForgeBlazor.Benchmark/RForgeBlazor.Benchmark.csproj
+++ b/src/RForge/RForgeBlazor.Benchmark/RForgeBlazor.Benchmark.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>disable</Nullable>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>disable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\RForgeBlazor\RForgeBlazor.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\RForgeBlazor\RForgeBlazor.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/src/RForge/RForgeBlazor/RForgeBlazor.csproj
+++ b/src/RForge/RForgeBlazor/RForgeBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <Nullable>disable</Nullable>
         <LangVersion>latest</LangVersion>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/RForge/RForgeTest/RForgeTest.Client/Pages/ModalPage.razor
+++ b/src/RForge/RForgeTest/RForgeTest.Client/Pages/ModalPage.razor
@@ -45,10 +45,10 @@
 </RfModal>
 
 <RfModalImage ImageUrl="@SelectedOption.DefaultImageUrl"
-              AspectRatio="@SelectedOption.AspectRatio" 
-              Width=@ImageCustomWidth 
-              ImageCaption=@ImageCaption
-              @bind-IsVisible=Example2IsVisible />
+AspectRatio="@SelectedOption.AspectRatio" 
+Width=@ImageCustomWidth 
+ImageCaption=@ImageCaption
+@bind-IsVisible=Example2IsVisible />
 
 <RfModalCard @bind-IsVisible="Example3IsVisible" ShowCloseButton="true">
     <Head>
@@ -249,9 +249,11 @@
         Example1IsVisible = true;
     }
 
-    private async Task OnDelete(bool userAcnkonwoledge)
+    private Task OnDelete(bool userAcnkonwoledge)
     {
-        if (userAcnkonwoledge == false) return;
+        if (userAcnkonwoledge == false) return Task.CompletedTask;
+
+        return Task.CompletedTask;
     }
 
 }

--- a/src/RForge/RForgeTest/RForgeTest.Client/Pages/NotificationManagerPage.razor
+++ b/src/RForge/RForgeTest/RForgeTest.Client/Pages/NotificationManagerPage.razor
@@ -60,9 +60,6 @@
 
 @code {
 
-
-    private int currentCount = 0;
-
     public string MessageText { get; set; }
     public string TitleText { get; set; }
     public RfNotificationSeverity Severity { get; set; }

--- a/src/RForge/RForgeTest/RForgeTest.Client/RForgeTest.Client.csproj
+++ b/src/RForge/RForgeTest/RForgeTest.Client/RForgeTest.Client.csproj
@@ -1,23 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>disable</Nullable>
-    <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
-    <StaticWebAssetProjectMode>Default</StaticWebAssetProjectMode>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>disable</Nullable>
+        <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
+        <StaticWebAssetProjectMode>Default</StaticWebAssetProjectMode>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.3" />
-  </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\RForgeBlazor\RForgeBlazor.csproj" />
-  </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="wwwroot\" />
-  </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.3" />
+    </ItemGroup>
+
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\RForgeBlazor\RForgeBlazor.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Folder Include="wwwroot\" />
+    </ItemGroup>
 
 </Project>

--- a/src/RForge/RForgeTest/RForgeTest/RForgeTest.csproj
+++ b/src/RForge/RForgeTest/RForgeTest/RForgeTest.csproj
@@ -1,18 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Nullable>disable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <Nullable>disable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\RForgeTest.Client\RForgeTest.Client.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.3" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\RForgeTest.Client\RForgeTest.Client.csproj" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="wwwroot\lib\" />
-  </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.3" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.1" />
+    </ItemGroup>
+    
+    <ItemGroup>
+        <Folder Include="wwwroot\lib\" />
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Support net8.0 and net9.0; various project updates

Updated target frameworks to support both net8.0 and net9.0 in multiple project files. Reformatted PropertyGroup and ItemGroup in RForgeBlazor.Benchmark.csproj for consistency. Improved readability of RfModalImage in ModalPage.razor. Modified OnDelete method in ModalPage.razor to return Task.CompletedTask. Removed currentCount field from NotificationManagerPage.razor. Conditionally included package references in RForgeTest.Client.csproj and RForgeTest.csproj based on target framework version.

+semver: feature