### PR TITLE
Refactor service registration in AddRfForgeBlazorServices

### DIFF
--- a/src/RForge/RForgeBlazor/RegisterServicesExtension.cs
+++ b/src/RForge/RForgeBlazor/RegisterServicesExtension.cs
@@ -18,10 +18,13 @@ namespace RForgeBlazor
         public static IServiceCollection AddRfForgeBlazorServices(this IServiceCollection services)
         {
 
-            services.AddScoped<INotificationManager, NotificationManager>();
-            services.AddScoped<INotificationManagerBackend, NotificationManager>();
-            services.AddScoped<IDialogManager, DialogManager>();
-            services.AddScoped<IDialogManagerBackend, DialogManager>();
+            services.AddScoped<NotificationManager>();
+            services.AddScoped<INotificationManager>(x => x.GetRequiredService<NotificationManager>());
+            services.AddScoped<INotificationManagerBackend>(x => x.GetRequiredService<NotificationManager>()); 
+            
+            services.AddScoped<DialogManager>();
+            services.AddScoped<IDialogManager>(x => x.GetRequiredService<DialogManager>());
+            services.AddScoped<IDialogManagerBackend>(x => x.GetRequiredService<DialogManager>());
 
             return services;
         }


### PR DESCRIPTION
#### PR Summary
Refactored service registrations to promote single instance usage for related interfaces.
- `RegisterServicesExtension.cs`: Modified `AddRfForgeBlazorServices` to register concrete implementations first, then resolve interfaces to those implementations.
