### PR TITLE
RfTreeView bug fix

### DIFF
--- a/src/RForge/RForgeBlazor/RfTreeNode.razor.css
+++ b/src/RForge/RForgeBlazor/RfTreeNode.razor.css
@@ -2,6 +2,7 @@
 
 .menu-list .button {
     --bulma-menu-list-link-padding: .25em .6em;
+    --bulma-button-padding-horizontal: var(--bulma-menu-list-link-padding);
     display: inline-block;
     width: unset;
 }


### PR DESCRIPTION
RfTreeView bug fix
- Fixed css issue where bulma instances that have larger padding on buttons would render correctly on the expand RfTreeNode.

+semver: patch