### PR TITLE
Patch/tree view deep selector

### DIFF
--- a/src/RForge/RForgeBlazor/RfTreeNode.razor.cs
+++ b/src/RForge/RForgeBlazor/RfTreeNode.razor.cs
@@ -264,18 +264,6 @@ public partial class RfTreeNode<TTreeItemData> : ComponentBase where TTreeItemDa
         return true;
     }
 
-    internal async Task Deselect()
-    {
-        if(await ChangeSelection(false) == true)
-            await Context.NodeSelectionChange(this);
-    }
-
-    internal async Task Collapse()
-    {
-        if (await ChangeExpansion(false) == true)
-            await Context.NodeExpandChange(this);
-    }
-
     private string ExpandTitleText
     {
         get

--- a/src/RForge/RForgeBlazor/RfTreeNode.razor.cs
+++ b/src/RForge/RForgeBlazor/RfTreeNode.razor.cs
@@ -184,7 +184,7 @@ public partial class RfTreeNode<TTreeItemData> : ComponentBase where TTreeItemDa
 
     private async Task OnNodeClickCallback()
     {
-        if (await ChangeSelection(true) == true)
+        if (await ChangeSelection(IsSelected == false) == true)
         {
             await Context.NodeSelectionChange(this);
         }

--- a/src/RForge/RForgeBlazor/RfTreeView.razor.cs
+++ b/src/RForge/RForgeBlazor/RfTreeView.razor.cs
@@ -52,9 +52,6 @@ public partial class RfTreeView<TTreeItemData> : ComponentBase, IDisposable wher
     public bool ShowAsPrerender { get; set; }
 
     private TreeViewContext<TTreeItemData> Context { get; set; }
-    private RfTreeNode<TTreeItemData> SelectedNode { get; set; }
-    private RfTreeNode<TTreeItemData> ExpandedNode { get; set; }
-
     /// <summary>
     /// Method invoked when the component is initialized.
     /// </summary>
@@ -68,8 +65,8 @@ public partial class RfTreeView<TTreeItemData> : ComponentBase, IDisposable wher
             AllowNodeClick = AllowClick
         };
 
-        Context.OnExpandedChange += Context_OnExpanded;
-        Context.OnSelectedChange += Context_OnSelected;
+        Context.OnExpandedChange += Context_OnExpandedChange;
+        Context.OnSelectedChange += Context_OnSelectedChange;
 
         base.OnInitialized();
     }
@@ -86,15 +83,13 @@ public partial class RfTreeView<TTreeItemData> : ComponentBase, IDisposable wher
         base.OnParametersSet();
     }
 
-    private async Task Context_OnSelected(object sender, RfTreeNode<TTreeItemData> selectedNode)
+    private Task Context_OnSelectedChange(object sender, RfTreeNode<TTreeItemData> selectedNode)
     {
-        if (SelectedNode != null && selectedNode != SelectedNode)
-            await SelectedNode.Deselect();
-
-        SelectedNode = selectedNode;
+        //Currently there is nothing plan for this event. Though adding something here would be nice.
+        return Task.CompletedTask;
     }
 
-    private Task Context_OnExpanded(object sender, RfTreeNode<TTreeItemData> expandedNode)
+    private Task Context_OnExpandedChange(object sender, RfTreeNode<TTreeItemData> expandedNode)
     {
         //Currently there is nothing plan for this event. Though adding something here would be nice.
         return Task.CompletedTask;
@@ -105,8 +100,8 @@ public partial class RfTreeView<TTreeItemData> : ComponentBase, IDisposable wher
     {
         if (Context != null)
         {
-            Context.OnExpandedChange -= Context_OnExpanded;
-            Context.OnSelectedChange -= Context_OnSelected;
+            Context.OnExpandedChange -= Context_OnExpandedChange;
+            Context.OnSelectedChange -= Context_OnSelectedChange;
         }
     }
 }


### PR DESCRIPTION
This pull request includes several changes aimed at refactoring and simplifying the codebase in the `RfTreeNode` and `RfTreeView` components within the `RForgeBlazor` project. The most important changes include modifying method names for consistency, removing unused methods, and updating the logic for node selection.

Refactoring and simplification:

* [`src/RForge/RForgeBlazor/RfTreeNode.razor.cs`](diffhunk://#diff-b8e7854ac0d0c64485f3fa84c38c55c79f7cfe715e01e363d18c44370554ed23L187-R187): Updated the `OnNodeClickCallback` method to use the `IsSelected` property for determining selection state.
* [`src/RForge/RForgeBlazor/RfTreeNode.razor.cs`](diffhunk://#diff-b8e7854ac0d0c64485f3fa84c38c55c79f7cfe715e01e363d18c44370554ed23L267-L278): Removed the unused `Deselect` and `Collapse` methods.
* [`src/RForge/RForgeBlazor/RfTreeView.razor.cs`](diffhunk://#diff-02c0f543686d7a69471a2563801d173977e30220a0f4160b92b1bdae84546ec0L55-L57): Removed the `SelectedNode` and `ExpandedNode` properties, as they are no longer needed.
* [`src/RForge/RForgeBlazor/RfTreeView.razor.cs`](diffhunk://#diff-02c0f543686d7a69471a2563801d173977e30220a0f4160b92b1bdae84546ec0L71-R69): Renamed event handler methods for expanded and selected changes to `Context_OnExpandedChange` and `Context_OnSelectedChange` for consistency. [[1]](diffhunk://#diff-02c0f543686d7a69471a2563801d173977e30220a0f4160b92b1bdae84546ec0L71-R69) [[2]](diffhunk://#diff-02c0f543686d7a69471a2563801d173977e30220a0f4160b92b1bdae84546ec0L89-R92) [[3]](diffhunk://#diff-02c0f543686d7a69471a2563801d173977e30220a0f4160b92b1bdae84546ec0L108-R104)