### PR TITLE
Added new Component RfContextMenu

### DIFF
--- a/docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Examples/ContextMenu/BasicExamplePage.razor
+++ b/docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Examples/ContextMenu/BasicExamplePage.razor
@@ -1,0 +1,79 @@
+﻿@page "/context-menu/example/basic-example"
+@using RForgeBlazor.Services
+@using RForgeDocs.Abstractions
+@using RForge.Abstractions.DropDowns
+@rendermode InteractiveAuto
+
+<ExampleDetail Title="Basic Example"
+               SubTitle="Basic / Static"
+               ComponentName="Context Menu"
+               PageSourceUrl="@RForgeHelpers.RepoDocsUrl("/RForgeDocs.Client/Pages/Examples/ContextMenu/BasicExamplePage.razor")"
+               ComponentDetailsUrl="/context-menu/details" />
+
+<div class="container">
+    <div class="columns">
+        <div class="column is-4">
+            <article class="section">
+
+                <div class="content">
+                    <p>
+                        This example showcases a static list of actions as part of a page heading.
+                    </p>
+                </div>
+            </article>
+        </div>
+        <div class="column">
+            <div class="is-flex is-justify-content-space-between">
+
+            <h1 class="title">Some Web Page</h1>
+                <RfContextMenu DropDownPosition=RfDropDownPosition.RightDown
+                               TriggerButtonCss=@Rf.ClassWhen(("is-loading", IsLoading == true))>
+
+                    <RfContextMenuLink OnClick=OnSaveClick>Save</RfContextMenuLink>
+                    <RfContextMenuLink Href="https://google.com" Target="_blank">Go to google.com</RfContextMenuLink>
+                    <RfContextMenuDivider />
+                    <RfContextMenuLink OnClick=OnArchiveClick>Archive</RfContextMenuLink>
+
+                    <RfContextMenuDivider />
+                    <RfContextMenuItem>
+
+                        <div class="has-text-centered">
+                            <span class="tag is-primary">Need Help</span> If you need any help please don't hesitate to contact us!
+                        </div>
+
+                    </RfContextMenuItem>
+
+                </RfContextMenu>
+            </div>
+        </div>
+    </div>
+</div>
+
+<RfNotificationManager />
+
+@code {
+
+    private bool IsLoading { get; set; }
+
+    [Inject]
+    public INotificationManager NotificationManager { get; set; }
+
+    private async Task OnSaveClick()
+    {
+        IsLoading = true;
+        StateHasChanged();
+        await Task.Delay(1000);
+
+        NotificationManager.AddSuccess("Successfully saved!");
+        IsLoading = false;
+    }
+
+    private async Task OnArchiveClick()
+    {
+        IsLoading = true;
+        await Task.Delay(1000);
+        NotificationManager.AddSuccess("Successfully archived!");
+        IsLoading = false;
+    }
+
+}

--- a/docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Examples/ContextMenu/LazyLoadingExamplePage.razor
+++ b/docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Examples/ContextMenu/LazyLoadingExamplePage.razor
@@ -1,0 +1,104 @@
+﻿@page "/context-menu/example/lazy-loading-example"
+@using RForgeBlazor.Services
+@using RForgeDocs.Abstractions
+@using RForge.Abstractions.DropDowns
+@rendermode InteractiveAuto
+
+<ExampleDetail Title="Lazy Loading Example"
+               SubTitle="Loading Menu on Click"
+               ComponentName="Context Menu"
+               PageSourceUrl="@RForgeHelpers.RepoDocsUrl("/RForgeDocs.Client/Pages/Examples/ContextMenu/LazyLoadingExamplePage.razor")"
+               ComponentDetailsUrl="/context-menu/details" />
+
+<div class="container">
+    <div class="columns">
+        <div class="column is-6">
+            <article class="section">
+
+                <div class="content">
+                    <p>
+                        This example showcases how to load the menu on click instead of having a static list of actions.
+                    </p>
+                    
+                    <p>
+                        This is accomplished by:
+
+                    </p>
+
+                    <ul>
+                        <li>Using the <code>@@bind-IsActive:after</code> parameter to trigger an async method.</li>
+                        <li>Loading the menu items in the async method.</li>
+                        <li>Setting the <code>IsHoverable</code> parameter to false so the menu open on hover only by clicking on the trigger button.</li>
+                        <li>Applying <code>.is-loading</code> to <code>TriggerButtonCss</code> when <code>IsActive == true && LoadedMenuItems == null</code></li>
+                    </ul>
+                </div>
+            </article>
+        </div>
+        <div class="column">
+            <div class="is-flex is-justify-content-space-between">
+
+                <h1 class="title">Some Web Page</h1>
+                <RfContextMenu DropDownPosition=RfDropDownPosition.RightDown
+                               IsHoverable=false
+                               @bind-IsActive=IsActive
+                               @bind-IsActive:after=OnContextMenuOpen
+                               TriggerButtonCss=@Rf.ClassWhen(("is-loading", IsActive == true && LoadedMenuItems == null))>
+
+                    @if (LoadedMenuItems != null)
+                    {
+                        <RfContextMenuItem>
+                            Choose your browser of choice!
+                        </RfContextMenuItem>
+                        <RfContextMenuDivider />
+
+                        foreach (var menuItem in LoadedMenuItems.OrderBy(o => o.Text))
+                        {
+                            <RfContextMenuLink Href=@menuItem.Url Target="_blank">@menuItem.Text</RfContextMenuLink>
+                        }
+                    }
+
+                </RfContextMenu>
+            </div>
+        </div>
+    </div>
+</div>
+
+<RfNotificationManager />
+
+@code {
+
+
+    [Inject]
+    public INotificationManager NotificationManager { get; set; }
+    private List<MenuItem> LoadedMenuItems { get; set; }
+    private bool IsActive { get; set; }
+
+    private async Task OnContextMenuOpen()
+    {
+        if (LoadedMenuItems == null)
+        {
+            await Task.Delay(4000);
+            LoadedMenuItems = new List<MenuItem>
+            {
+                new MenuItem{ Text = "Arc Browser", Url = "https://arc.net/download" },
+                new MenuItem{ Text = "Brave", Url = "https://brave.com/download/" },
+                new MenuItem{ Text = "DuckDuckGo", Url = "https://duckduckgo.com/" },
+                new MenuItem{ Text = "Google Chrome", Url = "https://www.google.com/chrome/bsem/download/en_us" },
+                new MenuItem{ Text = "Mozilla Firefox", Url = "https://www.mozilla.org/en-US/firefox/" },
+                new MenuItem{ Text = "Microsoft Edge", Url = "https://www.microsoft.com/en-us/edge/" },
+                new MenuItem{ Text = "Opera", Url = "https://www.opera.com/computer/" },
+                new MenuItem{ Text = "Safari", Url = "https://www.apple.com/safari/" },
+                new MenuItem{ Text = "Vivaldi", Url = "https://vivaldi.com/" },
+                new MenuItem{ Text = "Waterfox", Url = "https://www.waterfox.net/" },
+            };
+        }
+    }
+
+
+    private class MenuItem
+    {
+        public string Text { get; set; }
+        public string Url { get; set; }
+    }
+
+}

--- a/docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Examples/ContextMenu/ListItemExamplePage.razor
+++ b/docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Examples/ContextMenu/ListItemExamplePage.razor
@@ -1,0 +1,107 @@
+﻿@page "/context-menu/example/list-example"
+@using RForgeBlazor.Services
+@using RForgeDocs.Abstractions
+@using RForge.Abstractions.DropDowns
+@using RForgeDocs.Abstractions.DataModels
+@using RForgeDocs.Abstractions.Services
+
+@rendermode InteractiveAuto
+
+<ExampleDetail Title="Repeating Menu Example"
+SubTitle="Context menu per row"
+ComponentName="Context Menu"
+PageSourceUrl="@RForgeHelpers.RepoDocsUrl("/RForgeDocs.Client/Pages/Examples/ContextMenu/ListItemExamplePage.razor")"
+ComponentDetailsUrl="/context-menu/details" />
+
+<div class="container">
+    <div class="columns">
+        <div class="column is-4">
+            <article class="section">
+
+                <div class="content">
+                    <p>
+                        This example showcases a context menu per row in a list.
+                    </p>
+                </div>
+            </article>
+        </div>
+        <div class="column">
+
+            <table class="table is-fulwidth">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Is Admin</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+
+                <tbody>
+                    @foreach (var user in Users)
+                    {
+                        <tr>
+                            <td>@user.FirstName @user.LastName</td>
+                            <td>@user.IsAdmin</td>
+                            <td>
+                                <RfContextMenu AllowIsActiveToggleClick=false TriggerButtonCss="is-small" >
+                                    <RfContextMenuLink OnClick=@(() => SwapUserName(user))>Swap first and last name</RfContextMenuLink>
+
+                                    @if(user.IsAdmin)
+                                    {
+                                        <RfContextMenuLink OnClick=@(() => MakeUserNonAdmin(user))>Make non-admin</RfContextMenuLink>
+                                    }
+                                    else
+                                    {
+                                        <RfContextMenuLink OnClick=@(() => MakeUserAdmin(user))>Make admin</RfContextMenuLink>
+                                    }
+
+                                </RfContextMenu>
+
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+
+        </div>
+    </div>
+</div>
+
+<RfNotificationManager />
+
+@code {
+
+    [Inject]
+    private IFindUsersProcessor FindUsersProcessor { get; set; }
+    [Inject]
+    public INotificationManager NotificationManager { get; set; }
+
+    public List<UserData> Users { get; set; } = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        Users = await FindUsersProcessor.Find(null, 10);
+    }
+
+    private void SwapUserName(UserData user)
+    {
+        var temp = user.FirstName;
+        user.FirstName = user.LastName;
+        user.LastName = temp;
+        
+        NotificationManager.AddSuccess("Users first and last name have been swapped.", "Successfully Swapped!");
+    }
+
+    private void MakeUserAdmin(UserData user)
+    {
+        user.IsAdmin = true;
+        NotificationManager.AddSuccess("User is now an admin.", "Successfully Promoted!");
+    }
+
+    private void MakeUserNonAdmin(UserData user)
+    {
+        user.IsAdmin = false;
+        NotificationManager.AddSuccess("User is no longer an admin.", "Successfully Demoted!");
+    }
+
+}

--- a/docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Playgrounds/ContextMenuPage.razor
+++ b/docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Playgrounds/ContextMenuPage.razor
@@ -1,0 +1,192 @@
+﻿@page "/context-menu/playground"
+@using RForge.Abstractions
+@using RForge.Abstractions.DropDowns
+@using RForgeBlazor.Services
+@using RForgeDocs.Abstractions.DataModels
+@using RForgeDocs.Abstractions.Services
+@rendermode InteractiveAuto
+
+@inject IFindUsersProcessor findUsersProcessor
+
+<PlaygroundDetails 
+                   PageSourceUrl="@RForgeHelpers.RepoDocsUrl("/RForgeDocs.Client/Pages/Playgrounds/ContextMenuPage.razor")"
+                   HasEvents=false
+                   MakeDisplaySticky=false
+                   SubTitle="Context Menu"
+                   ComponentName="Context Menu"
+                   Title="Playground"
+                   ComponentDetailsUrl="/context-menu/details">
+
+    <Parameters>
+
+        <BulmaCheckbox Label="IsActive"
+                       HelpText="Gets or sets a value indicating whether the context menu is active.">
+            <InputCheckbox @bind-Value=@IsActive class="checkbox" />
+        </BulmaCheckbox>
+
+        <BulmaCheckbox Label="AllowIsActiveToggleClick"
+                       HelpText="Gets or sets a value indicating whether the context menu allows toggling its active state on click. Default is true.">
+            <InputCheckbox @bind-Value=@AllowIsActiveToggleClick class="checkbox" />
+        </BulmaCheckbox>
+
+        <BulmaCheckbox Label="IsHoverable"
+                       HelpText="Gets or sets a value indicating whether the context menu is hoverable.">
+            <InputCheckbox @bind-Value=@IsHoverable class="checkbox" />
+        </BulmaCheckbox>
+
+        <BulmaInput Label="Position"
+                    HelpText="Gets or sets the position of the context menu.">
+            <div class="select is-primary">
+                <select @bind=Position>
+                    @foreach (var position in Enum.GetValues(typeof(RfPosition)))
+                    {
+                        <option value="@position">@position</option>
+                    }
+                </select>
+            </div>
+        </BulmaInput>
+
+        <BulmaInput Label="CssClass"
+                    HelpText="Gets or sets the CSS class for the context menu.">
+            <InputText @bind-Value="CssClass" type="text" class="input" />
+        </BulmaInput>
+
+        <BulmaInput Label="TriggerButtonCss"
+                    HelpText="Gets or sets the CSS class for the trigger button.">
+            <InputText @bind-Value="TriggerButtonCss" type="text" class="input" />
+        </BulmaInput>
+
+        <BulmaInput Label="DropDownPosition"
+                    HelpText="Gets or sets the position of the dropdown.">
+            <div class="select is-primary">
+                <select @bind=DropDownPosition>
+                    @foreach (var dropDownPosition in Enum.GetValues(typeof(RfDropDownPosition)))
+                    {
+                        <option value="@dropDownPosition">@dropDownPosition</option>
+                    }
+                </select>
+            </div>
+        </BulmaInput>
+
+        <BulmaInput Label="DropDownIcon"
+                    HelpText="Gets or sets the icon for the dropdown.">
+            <InputText @bind-Value="DropDownIcon" type="text" class="input" />
+        </BulmaInput>
+
+        <BulmaInput Label="IsActiveTriggerButtonCss"
+                    HelpText="Gets or sets the CSS class for the active trigger button.">
+            <InputText @bind-Value="IsActiveTriggerButtonCss" type="text" class="input" />
+        </BulmaInput>
+
+        <BulmaInput Label="TriggerText"
+                    HelpText="Gets or sets the text for the trigger button.">
+            <InputText @bind-Value="TriggerText" type="text" class="input" />
+        </BulmaInput>
+
+    </Parameters>
+
+    <Display>
+
+        <div class="box is-relative" style="width: 100%; height: 500px;">
+            <RfContextMenu 
+                            @bind-IsActive=IsActive
+                           AllowIsActiveToggleClick=AllowIsActiveToggleClick
+                           IsHoverable=IsHoverable
+                           CssClass=@CssClass
+                           TriggerButtonCss=@TriggerButtonCss
+                           DropDownPosition=@DropDownPosition
+                           DropDownIcon=@DropDownIcon
+                           IsActiveTriggerButtonCss=@IsActiveTriggerButtonCss
+                           TriggerText=@TriggerText
+                           Position=Position>
+
+                <RfContextMenuItem>Some Text</RfContextMenuItem>
+                <RfContextMenuItem>Some other text</RfContextMenuItem>
+                <RfContextMenuLink OnClick=OnContextMenuLinkClick>Show Alert!</RfContextMenuLink>
+                <RfContextMenuDivider />
+                <RfContextMenuLink Href="https://rforge.azurewebsites.net/context-menu/details">Back to Details</RfContextMenuLink>
+
+            </RfContextMenu>
+        </div>
+
+    </Display>
+
+</PlaygroundDetails>
+
+<RfNotificationManager />
+
+@code {
+
+    [Inject]
+    public INotificationManager NotificationManager { get; set; }
+
+    private void OnContextMenuLinkClick()
+    {
+        NotificationManager.AddSuccess("You clicked the link!");
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the context menu is active.
+    /// </summary>
+
+    public bool IsActive { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the context menu allows toggling its active state on click. Default is true.
+    /// You can still manually set the IsActive parameter to control the state programmatically.
+    /// </summary>
+
+    public bool AllowIsActiveToggleClick { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the callback that is invoked when the IsActive property changes.
+    /// </summary>
+
+    public EventCallback<bool> IsActiveChanged { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the context menu is hoverable.
+    /// </summary>
+
+    public bool IsHoverable { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the position of the context menu.
+    /// </summary>
+
+    public RfPosition Position { get; set; } = RfPosition.Unset;
+
+    /// <summary>
+    /// Gets or sets the CSS class for the context menu.
+    /// </summary>
+
+    public string CssClass { get; set; }
+
+    /// <summary>
+    /// Gets or sets the CSS class for the trigger button.
+    /// </summary>
+
+    public string TriggerButtonCss { get; set; }
+
+    /// <summary>
+    /// Gets or sets the position of the dropdown.
+    /// </summary>
+
+    public RfDropDownPosition DropDownPosition { get; set; } = RfDropDownPosition.LeftDown;
+
+    /// <summary>
+    /// Gets or sets the icon for the dropdown.
+    /// </summary>
+
+    public string DropDownIcon { get; set; } = "fa-solid fa-ellipsis";
+
+
+    public string IsActiveTriggerButtonCss { get; set; } = "is-primary";
+
+    /// <summary>
+    /// Gets or sets the text for the trigger button.
+    /// </summary>
+
+    public string TriggerText { get; set; }
+
+}

--- a/docs/RForgeDocs/RForgeDocs/RForgeDocs/Components/Pages/ComponentDetail/ContextMenuPage.razor
+++ b/docs/RForgeDocs/RForgeDocs/RForgeDocs/Components/Pages/ComponentDetail/ContextMenuPage.razor
@@ -1,0 +1,143 @@
+﻿@page "/context-menu/details"
+
+<ComponentDetail Title="Context Menu"
+                 PlaygroundUrl="/context-menu/playground"
+                 SubTitle="A drop down of actions to declutter the UI">
+
+    <Examples>
+        @ComponentDetail.SideLink(("Basic example", TagInfo.Empty, "/context-menu/example/basic-example"))
+        @ComponentDetail.SideLink(("Lazy loading example", TagInfo.Empty, "/context-menu/example/lazy-loading-example"))
+        @ComponentDetail.SideLink(("In a list example", TagInfo.Empty, "/context-menu/example/list-example"))
+
+    </Examples>
+
+    <RepoLinks>
+        @ComponentDetail.SideLink(("RfContextMenu.razor", TagInfo.Razor, "https://github.com/Rumhyek/RForge/blob/main/src/RForge/RForgeBlazor/RfContextMenu.razor"))
+        @ComponentDetail.SideLink(("RfContextMenu.razor.cs", TagInfo.Backend, "https://github.com/Rumhyek/RForge/blob/main/src/RForge/RForgeBlazor/RfContextMenu.razor.cs"))
+        @ComponentDetail.SideLink(("RfContextMenu.razor.css", TagInfo.Css, "https://github.com/Rumhyek/RForge/blob/main/src/RForge/RForgeBlazor/RfContextMenu.razor.css"))
+        @ComponentDetail.SpacerLink()
+        @ComponentDetail.SideLink(("RfContextMenuDivider.razor", TagInfo.Razor, "https://github.com/Rumhyek/RForge/blob/main/src/RForge/RForgeBlazor/RfContextMenuDivider.razor"))
+        @ComponentDetail.SideLink(("RfContextMenuDivider.razor.cs", TagInfo.Backend, "https://github.com/Rumhyek/RForge/blob/main/src/RForge/RForgeBlazor/RfContextMenuDivider.razor.cs"))
+        @ComponentDetail.SpacerLink()
+        @ComponentDetail.SideLink(("RfContextMenuItem.razor", TagInfo.Razor, "https://github.com/Rumhyek/RForge/blob/main/src/RForge/RForgeBlazor/RfContextMenuItem.razor"))
+        @ComponentDetail.SideLink(("RfContextMenuItem.razor.cs", TagInfo.Backend, "https://github.com/Rumhyek/RForge/blob/main/src/RForge/RForgeBlazor/RfContextMenuItem.razor.cs"))
+        @ComponentDetail.SpacerLink()
+        @ComponentDetail.SideLink(("RfContextMenuLink.razor", TagInfo.Razor, "https://github.com/Rumhyek/RForge/blob/main/src/RForge/RForgeBlazor/RfContextMenuLink.razor"))
+        @ComponentDetail.SideLink(("RfContextMenuLink.razor.cs", TagInfo.Backend, "https://github.com/Rumhyek/RForge/blob/main/src/RForge/RForgeBlazor/RfContextMenuLink.razor.cs"))
+        @ComponentDetail.SpacerLink()
+        @ComponentDetail.SideLink(("RfDropDownPosition.cs", TagInfo.Enum, "https://github.com/Rumhyek/RForge/blob/main/src/RForge/RForge.Abstractions/DropDowns/RfDropDownPosition.cs"))
+        @ComponentDetail.SideLink(("RfPosition.cs", TagInfo.Enum, "https://github.com/Rumhyek/RForge/blob/main/src/RForge/RForge.Abstractions/DropDowns/RfPosition.cs"))
+    </RepoLinks>
+
+    <Purpose>
+        <div class="content">
+
+            <p>
+                The Context Menu component is a versatile and interactive UI element designed to enhance user experience by providing
+                a context-specific menu of actions or options. It makes uses of Bulma `.dropdown` classes to create a dropdown menu.
+            </p>
+
+            <h3>When to Use</h3>
+            <p>
+                Use the Context Menu component when you need to offer users a set of actions or options that are relevant to a specific
+                context or element on the page. It is particularly useful for:
+            </p>
+            <ul>
+                <li>Providing additional options for a selected item or element.</li>
+                <li>Offering context-specific actions without cluttering the UI.</li>
+                <li>Enhancing user interaction by displaying relevant choices based on the current context.</li>
+            </ul>
+
+        </div>
+    </Purpose>
+
+    <BasicUsage>
+        <div class="content">
+            <p>
+                To activate the context menu the user must left click or press enter on the trigger element.
+            </p>
+
+            <p>
+                By default the menu will be positioned inline and will open to the bottom left
+                of the trigger element on hover or stay open if the trigger element is clicked.
+                The context menu also shows the icon <code>fa-solid fa-ellipsis</code> with no text by default.
+                Both of these can be changed by setting the <code>TriggerText</code> and <code>TriggerButtonCss</code> parameters.
+            </p>
+
+            <p>
+                The menu can be configured to open in different directions by setting the <code>RfContextMenu.DropDownPosition</code> parameter.
+                The menu can be positioned in the four corners based on <code>RfContextMenu.Position</code> parameter.
+            </p>
+
+            <p>
+                The <code>ChildContent</code> of the <code>RfContextMenu</code> component can contain any number of <code>RfContextMenuItem</code>
+                and <code>RfContextMenuLink</code> components. The <code>RfContextMenuDivider</code> component can be used to create a divider
+                between groups of menu items.
+            </p>
+
+            <pre><code>&lt;RfContextMenu &gt;
+    &lt;RfContextMenuItem&gt;Some Text&lt;/RfContextMenuItem&gt;
+    &lt;RfContextMenuItem&gt;Some other text&lt;/RfContextMenuItem&gt;
+    &lt;RfContextMenuDivider /&gt;
+    &lt;RfContextMenuLink Href="#"&gt;Link&lt;/RfContextMenuLink&gt;
+&lt;/RfContextMenu&gt;</code></pre>
+
+            <h3>RfContextMenuItem</h3>
+            <p>
+                The <code>RfContextMenuItem</code> is used to add no interactive text to the menu. 
+                You can add any content you want inside the component including something that is interactive.
+            </p>
+            <h3>RfContextMenuLink</h3>
+            <p>
+                The <code>RfContextMenuLink</code> component supports the <code>OnClick</code> event as well as all the parameters of the <code>&lt;a&gt;</code> tag.
+            </p>
+
+            <h3>Dynamic / Lazy Loading</h3>
+            <p>
+                You can make the menu dynamically load items by binding to <code>@@bind-IsActive:after</code>.
+                However, you will have to set <code>IsHoverable</code> to false because the hover action is controlled by css and a event cannot be triggered on hover.
+                In the same way you can add a the css class <code>.is-loading</code> to the <code>TriggerButtonCss</code> during the loading state to show a loading spinner.
+            </p>
+            <h4>Dynamic Loading Example</h4>
+            <pre><code>&lt;RfContextMenu @@bind-IsActive:after=@@LoadContextMenu 
+    TriggerButtonCss="@@Rf.ClassWhen(("is-loading", IsLoaded))"&gt;
+    @@if(IsLoaded == true)
+    {
+        &lt;RfContextMenuItem&gt;Some Text&lt;/RfContextMenuItem&gt;
+        &lt;RfContextMenuItem&gt;Some other text&lt;/RfContextMenuItem&gt;
+        &lt;RfContextMenuDivider /&gt;
+        &lt;RfContextMenuLink Href="#"&gt;Link&lt;/RfContextMenuLink&gt;
+    }
+&lt;/RfContextMenu&gt;</code></pre>
+
+            <h2>CSS Variables</h2>
+            <p>
+                <code>RfContextMenu</code> adds additional CSS variables applied at the root <code>.dropdown</code>.
+            </p>
+
+            <table class="table is-fullwidth is-striped">
+
+                <thead>
+                    <tr>
+                        <th>CSS Variable</th>
+                        <th>Value</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><code>--rf-position-spacing</code></td>
+                        <td><code>0</code></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </BasicUsage>
+
+    <Setup>
+        <BasicSetupDetails />
+    </Setup>
+</ComponentDetail>
+
+@code {
+
+}

--- a/docs/RForgeDocs/RForgeDocs/RForgeDocs/Components/Pages/ComponentsPage.razor
+++ b/docs/RForgeDocs/RForgeDocs/RForgeDocs/Components/Pages/ComponentsPage.razor
@@ -24,6 +24,7 @@
                         <div class="menu">
                             <p class="menu-label">General Components</p>
                             <ul class="menu-list">
+                                <li><a href="/context-menu/details">Context Menu</a></li>
                                 <li><a href="/markdown/details">Markdown</a></li>
                             </ul>
 

--- a/src/RForge/RForge.Abstractions/DropDowns/RfPosition.cs
+++ b/src/RForge/RForge.Abstractions/DropDowns/RfPosition.cs
@@ -1,0 +1,28 @@
+﻿namespace RForge.Abstractions.DropDowns;
+
+/// <summary>
+/// The position of the element.
+/// </summary>
+public enum RfPosition
+{
+    /// <summary>
+    /// Does not set a position leaving it as is.
+    /// </summary>
+    Unset,
+    /// <summary>
+    /// Position at the top right. Requires parent to be relative.
+    /// </summary>
+    TopRight,
+    /// <summary>
+    /// Position at the top left. Requires parent to be relative.
+    /// </summary>
+    TopLeft,
+    /// <summary>
+    /// Position at the bottom right. Requires parent to be relative.
+    /// </summary>
+    BottomRight,
+    /// <summary>
+    /// Position at the bottom left. Requires parent to be relative.
+    /// </summary>
+    BottomLeft,
+}

--- a/src/RForge/RForgeBlazor/RfContextMenu.razor
+++ b/src/RForge/RForgeBlazor/RfContextMenu.razor
@@ -1,0 +1,21 @@
+<div class="dropdown @CssClass @DropDownDirectionCss @PositionCss @Rf.ClassWhen(("is-active", IsActive), ("is-hoverable", IsHoverable))">
+    <div class="dropdown-trigger">
+        <button class="button @TriggerButtonCss @Rf.ClassWhen((IsActiveTriggerButtonCss, IsActive))"
+                @onclick=ToggleIsActiveClick
+                aria-haspopup="true" 
+                aria-controls="context-menu-@DropDownId">
+            @if(string.IsNullOrWhiteSpace(TriggerText) == false)
+            {
+                <span>@TriggerText</span>
+            }
+            <span class="icon is-small">
+                <i class="@DropDownIcon" aria-hidden="true"></i>
+            </span>
+        </button>
+    </div>
+    <div class="dropdown-menu" id="context-menu-@DropDownId" role="menu">
+        <div class="dropdown-content">
+            @ChildContent
+        </div>
+    </div>
+</div>

--- a/src/RForge/RForgeBlazor/RfContextMenu.razor
+++ b/src/RForge/RForgeBlazor/RfContextMenu.razor
@@ -1,6 +1,6 @@
 <div class="dropdown @CssClass @DropDownDirectionCss @PositionCss @Rf.ClassWhen(("is-active", IsActive), ("is-hoverable", IsHoverable))">
     <div class="dropdown-trigger">
-        <button class="button @TriggerButtonCss @Rf.ClassWhen((IsActiveTriggerButtonCss, IsActive))"
+        <button type="button" class="button @TriggerButtonCss @Rf.ClassWhen((IsActiveTriggerButtonCss, IsActive))"
                 @onclick=ToggleIsActiveClick
                 aria-haspopup="true" 
                 aria-controls="context-menu-@DropDownId">

--- a/src/RForge/RForgeBlazor/RfContextMenu.razor.cs
+++ b/src/RForge/RForgeBlazor/RfContextMenu.razor.cs
@@ -1,0 +1,119 @@
+using Microsoft.AspNetCore.Components;
+using RForge.Abstractions.DropDowns;
+
+namespace RForgeBlazor;
+/// <summary>
+/// Represents a context menu component making use of Bulma dropdown component.
+/// </summary>
+public partial class RfContextMenu
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the context menu is active.
+    /// </summary>
+    [Parameter]
+    public bool IsActive { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the context menu allows toggling its active state on click. Default is true. 
+    /// You can still manually set the IsActive parameter to control the state programmatically.
+    /// </summary>
+    [Parameter]
+    public bool AllowIsActiveToggleClick { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the callback that is invoked when the IsActive property changes.
+    /// </summary>
+    [Parameter]
+    public EventCallback<bool> IsActiveChanged { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the context menu is hoverable.
+    /// </summary>
+    [Parameter]
+    public bool IsHoverable { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the position of the context menu.
+    /// </summary>
+    [Parameter]
+    public RfPosition Position { get; set; } = RfPosition.Unset;
+
+    /// <summary>
+    /// Gets or sets the CSS class for the context menu.
+    /// </summary>
+    [Parameter]
+    public string CssClass { get; set; }
+
+    /// <summary>
+    /// Gets or sets the CSS class for the trigger button.
+    /// </summary>
+    [Parameter]
+    public string TriggerButtonCss { get; set; }
+
+    /// <summary>
+    /// Gets or sets the position of the dropdown.
+    /// </summary>
+    [Parameter]
+    public RfDropDownPosition DropDownPosition { get; set; } = RfDropDownPosition.LeftDown;
+
+    /// <summary>
+    /// Gets or sets the icon for the dropdown.
+    /// </summary>
+    [Parameter]
+    public string DropDownIcon { get; set; } = "fa-solid fa-ellipsis";
+
+    [Parameter]
+    public string IsActiveTriggerButtonCss { get; set; } = "is-primary";
+
+    /// <summary>
+    /// Gets or sets the text for the trigger button.
+    /// </summary>
+    [Parameter]
+    public string TriggerText { get; set; }
+
+    /// <summary>
+    /// Gets or sets the child content to be rendered inside the context menu.
+    /// </summary>
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
+
+    private int DropDownId { get; set; } = new Random().Next(100000, 999999);
+
+    private string DropDownDirectionCss
+    {
+        get
+        {
+            return DropDownPosition switch
+            {
+                RfDropDownPosition.LeftDown => null,
+                RfDropDownPosition.RightDown => "is-right",
+                RfDropDownPosition.LeftUp => "is-up",
+                RfDropDownPosition.RightUp => "is-up is-right",
+                _ => null
+            };
+        }
+    }
+
+    private string PositionCss
+    {
+        get
+        {
+            return Position switch
+            {
+                RfPosition.Unset => null,
+                RfPosition.TopRight => "is-top-right",
+                RfPosition.TopLeft => "is-top-left",
+                RfPosition.BottomRight => "is-bottom-right",
+                RfPosition.BottomLeft => "is-bottom-left",
+                _ => null
+            };
+        }
+    }
+
+    private async Task ToggleIsActiveClick()
+    {
+        if (AllowIsActiveToggleClick == false) return;
+        IsActive = IsActive == false;
+        await IsActiveChanged.InvokeAsync(IsActive);
+    }
+}

--- a/src/RForge/RForgeBlazor/RfContextMenu.razor.cs
+++ b/src/RForge/RForgeBlazor/RfContextMenu.razor.cs
@@ -61,7 +61,10 @@ public partial class RfContextMenu
     /// </summary>
     [Parameter]
     public string DropDownIcon { get; set; } = "fa-solid fa-ellipsis";
-
+    
+    /// <summary>
+    /// Gets or sets the CSS class for the trigger button when the context menu is active.
+    /// </summary>
     [Parameter]
     public string IsActiveTriggerButtonCss { get; set; } = "is-primary";
 

--- a/src/RForge/RForgeBlazor/RfContextMenu.razor.css
+++ b/src/RForge/RForgeBlazor/RfContextMenu.razor.css
@@ -1,0 +1,29 @@
+﻿
+
+.dropdown {
+    --rf-position-spacing: 0;
+}
+
+    .dropdown.is-top-right {
+        position: absolute;
+        top: var(--rf-position-spacing);
+        right: var(--rf-position-spacing);
+    }
+
+    .dropdown.is-top-left {
+        position: absolute;
+        top: var(--rf-position-spacing);
+        left: var(--rf-position-spacing);
+    }
+
+    .dropdown.is-bottom-right {
+        position: absolute;
+        bottom: var(--rf-position-spacing);
+        right: var(--rf-position-spacing);
+    }
+
+    .dropdown.is-bottom-left {
+        position: absolute;
+        bottom: var(--rf-position-spacing);
+        left: var(--rf-position-spacing);
+    }

--- a/src/RForge/RForgeBlazor/RfContextMenuDivider.razor
+++ b/src/RForge/RForgeBlazor/RfContextMenuDivider.razor
@@ -1,0 +1,2 @@
+
+<hr class="dropdown-divider @CssClass" />

--- a/src/RForge/RForgeBlazor/RfContextMenuDivider.razor.cs
+++ b/src/RForge/RForgeBlazor/RfContextMenuDivider.razor.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Components;
+
+namespace RForgeBlazor;
+/// <summary>
+/// Represents a divider in a context menu.
+/// </summary>
+public partial class RfContextMenuDivider
+{
+    /// <summary>
+    /// Gets or sets the CSS class for the divider.
+    /// </summary>
+    [Parameter]
+    public string CssClass { get; set; }
+}

--- a/src/RForge/RForgeBlazor/RfContextMenuItem.razor
+++ b/src/RForge/RForgeBlazor/RfContextMenuItem.razor
@@ -1,0 +1,4 @@
+
+<div class="dropdown-item @CssClass">
+    @ChildContent
+</div>

--- a/src/RForge/RForgeBlazor/RfContextMenuItem.razor.cs
+++ b/src/RForge/RForgeBlazor/RfContextMenuItem.razor.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Components;
+
+namespace RForgeBlazor;
+/// <summary>
+/// Represents a context menu item component. Renders a non-clickable item in a context menu via div.dropdown-item.
+/// </summary>
+public partial class RfContextMenuItem
+{
+    /// <summary>
+    /// Gets or sets the CSS class for the context menu item.
+    /// </summary>
+    [Parameter]
+    public string CssClass { get; set; }
+
+    /// <summary>
+    /// Gets or sets the child content to be rendered inside the context menu item.
+    /// </summary>
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
+}

--- a/src/RForge/RForgeBlazor/RfContextMenuLink.razor
+++ b/src/RForge/RForgeBlazor/RfContextMenuLink.razor
@@ -1,0 +1,8 @@
+
+
+<a class="dropdown-item @CssClass" 
+   href=@Href 
+   target=@Target
+   @onclick=OnClick>
+    @ChildContent
+</a>

--- a/src/RForge/RForgeBlazor/RfContextMenuLink.razor.cs
+++ b/src/RForge/RForgeBlazor/RfContextMenuLink.razor.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Components;
+
+namespace RForgeBlazor;
+/// <summary>
+/// Represents a context menu link component. Renders a clickable link in a context menu via a.
+/// </summary>
+public partial class RfContextMenuLink
+{
+    /// <summary>
+    /// Gets or sets the URL of the link.
+    /// </summary>
+    [Parameter]
+    public string Href { get; set; }
+
+    [Parameter]
+    public EventCallback OnClick { get; set; }
+
+    /// <summary>
+    /// Gets or sets the target attribute of the link.
+    /// </summary>
+    [Parameter]
+    public string Target { get; set; }
+
+    /// <summary>
+    /// Gets or sets the CSS class of the link.
+    /// </summary>
+    [Parameter]
+    public string CssClass { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content to be rendered inside the link.
+    /// </summary>
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
+}

--- a/src/RForge/RForgeTest/RForgeTest.Client/Pages/ContextMenuPage.razor
+++ b/src/RForge/RForgeTest/RForgeTest.Client/Pages/ContextMenuPage.razor
@@ -1,0 +1,78 @@
+﻿@page "/context-menu"
+@using RForge.Abstractions.DropDowns
+@rendermode InteractiveAuto
+
+<PageTitle>Context Menu</PageTitle>
+
+<h1>Context Menu</h1>
+
+
+
+<div class="box is-relative is-flex is-justify-content-center is-align-content-center" style="width: 500px; height: 500px;">
+    <div>
+        <button style="@Rf.StyleWhen(("--button-active-color", "red", true))" class="button">Free Money</button>
+        <RfContextMenu DropDownIcon="fa-solid fa-question" TriggerButtonCss="is-ghost" DropDownPosition=RfDropDownPosition.LeftDown AllowIsActiveToggleClick=false>
+            <RfContextMenuItem>
+                <p class="help">THis is the best button to press whenyou want to get free money.</p>
+            </RfContextMenuItem>
+        </RfContextMenu>
+
+    </div>
+    <RfContextMenu Position=RfPosition.TopLeft IsHoverable=false>
+        <RfContextMenuItem>Item 1</RfContextMenuItem>
+        <RfContextMenuItem>Item 2</RfContextMenuItem>
+        <RfContextMenuItem>Item 3</RfContextMenuItem>
+        <RfContextMenuItem>Item 4</RfContextMenuItem>
+        <RfContextMenuItem>Item 5</RfContextMenuItem>
+        <RfContextMenuItem>Item 6</RfContextMenuItem>
+        <RfContextMenuItem>Item 7</RfContextMenuItem>
+    </RfContextMenu>
+
+    <RfContextMenu Position=RfPosition.TopRight DropDownPosition=RfDropDownPosition.RightDown CssClass="@Rf.ClassWhen((Test, false == true), (Test2, true == true))">
+        <RfContextMenuLink Href="#1">Item 1</RfContextMenuLink>
+        <RfContextMenuLink Href="#2">Item 2</RfContextMenuLink>
+        <RfContextMenuLink Href="#3">Item 3</RfContextMenuLink>
+        <RfContextMenuLink Href="#4">Item 4</RfContextMenuLink>
+        <RfContextMenuLink Href="#5">Item 5</RfContextMenuLink>
+        <RfContextMenuLink Href="#6">Item 6</RfContextMenuLink>
+        <RfContextMenuLink OnClick=@(() => Console.WriteLine("OnClick"))>Item 7</RfContextMenuLink>
+    </RfContextMenu>
+    <RfContextMenu Position=RfPosition.BottomLeft DropDownPosition=RfDropDownPosition.LeftUp>
+
+        <RfContextMenuItem>
+            <p style="@Rf.StyleWhen(("color", Test, Test == Test2))">
+                You can insert <strong>any type of content</strong> within the
+                dropdown menu.
+            </p>
+        </RfContextMenuItem>
+
+        <RfContextMenuDivider />
+        <RfContextMenuItem>
+            <p>You simply need to use a <code>&lt;div&gt;</code> instead.</p>
+        </RfContextMenuItem>
+        <RfContextMenuDivider />
+        <RfContextMenuLink Href="#"> This is a link </RfContextMenuLink>
+    </RfContextMenu>
+    <RfContextMenu Position=RfPosition.BottomRight DropDownPosition=RfDropDownPosition.RightUp>
+
+        <div class="dropdown-item">
+            <p>
+                You can insert <strong>any type of content</strong> within the
+                dropdown menu.
+            </p>
+        </div>
+        <hr class="dropdown-divider" />
+        <div class="dropdown-item">
+            <p>You simply need to use a <code>&lt;div&gt;</code> instead.</p>
+        </div>
+        <hr class="dropdown-divider" />
+        <a href="#" class="dropdown-item"> This is a link </a>
+
+    </RfContextMenu>
+</div>
+
+
+@code {
+    public string Test { get; set; } = "est";
+    public string Test2 { get; set; } = "est";
+}

--- a/src/RForge/RForgeTest/RForgeTest/Components/Layout/NavMenu.razor
+++ b/src/RForge/RForgeTest/RForgeTest/Components/Layout/NavMenu.razor
@@ -42,6 +42,9 @@
             <NavLink class="navbar-item" href="treeview">
                 Treeview
             </NavLink>
+            <NavLink class="navbar-item" href=context-menu>
+                Context Menu
+            </NavLink>
 
         </div>
     </div>

--- a/src/RForge/RForgeTest/RForgeTest/Program.cs
+++ b/src/RForge/RForgeTest/RForgeTest/Program.cs
@@ -26,7 +26,13 @@ else
     app.UseExceptionHandler("/Error", createScopeForErrors: true);
 }
 
+#if NET8_0
 app.UseStaticFiles();
+#endif
+#if NET9_0_OR_GREATER
+app.MapStaticAssets();
+#endif
+
 app.UseAntiforgery();
 
 app.MapRazorComponents<App>()


### PR DESCRIPTION
This pull request adds `RfContextMenu`. It adds in addition to this component.
- `RfContextMenuItem` - Used to house text related items within the `RfContextMenu`
- `RfContextMenuLink` - Used to add a link or click action to the context menu.
- `RfContextMenuDivider` - Used to add a separator line.

This new component is based off Bulma Dropdown.

Also, this pull request introduces several new example pages and a playground page for the Context Menu component in the `RForgeDocs` documentation. The changes include the addition of basic, lazy loading, and list item examples, as well as a detailed context menu playground page.

New example pages:

* [`docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Examples/ContextMenu/BasicExamplePage.razor`](diffhunk://#diff-fe3d9a89afa385385d43127364a235bec7d6405df25d6c9b589bed172a46eb74R1-R79): Added a basic example page showcasing a static list of actions in a context menu.
* [`docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Examples/ContextMenu/LazyLoadingExamplePage.razor`](diffhunk://#diff-42a33125934debc5a5467cd86b05e54f826d5388492e8fb333dea8fbf2a2ade0R1-R104): Added a lazy loading example page demonstrating how to load menu items asynchronously on click.
* [`docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Examples/ContextMenu/ListItemExamplePage.razor`](diffhunk://#diff-5d0ab74caa566085a229e4cf57ffee945c232a1a31508bb407209030d77d60ddR1-R107): Added an example page that shows a context menu for each row in a list.

New playground page:

* [`docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Playgrounds/ContextMenuPage.razor`](diffhunk://#diff-926cbc5db1b2a1ec8cc79459771b34dc2a6c0d1044fb0b9587ec43e6517a2654R1-R192): Added a playground page for the Context Menu component with various configurable parameters to test different scenarios.

Component detail page update:

* [`docs/RForgeDocs/RForgeDocs/RForgeDocs/Components/Pages/ComponentDetail/ContextMenuPage.razor`](diffhunk://#diff-e4c47bd71bd170979c058b9f82de4fa7e45ceab825d0e4e7e5b1c2cdd72d1b8eR1-R143): Updated the component detail page to include links to the new example pages and provide detailed usage information for the Context Menu component.

Closes #10 