### PR TITLE
Fixed #34 issue null items.

### DIFF
--- a/src/RForge/RForgeBlazor/RfDropDown.razor
+++ b/src/RForge/RForgeBlazor/RfDropDown.razor
@@ -62,7 +62,7 @@
                             showAtTop = true;
                             break;
                         case RfShowSelectionInDropDown.OnlyWhenNotInList:
-                            showAtTop = Items.Any(i => IsSelected(i) == true) == false;
+                            showAtTop = Items == null || Items.Any(i => IsSelected(i) == true) == false;
                             break;
                     }
                 }


### PR DESCRIPTION
Fix showAtTop logic in RfDropDown.razor

Updated the condition for the `showAtTop` variable to include a check for null `Items`. This ensures that `showAtTop` is set to true if `Items` is null or if no items are selected.

#34 closes
#semver: patch