### PR TITLE
Fixing the same bug in the multi dropdown.

### DIFF
--- a/src/RForge/RForgeBlazor/RfDropDownMulti.razor
+++ b/src/RForge/RForgeBlazor/RfDropDownMulti.razor
@@ -85,7 +85,7 @@
                                 showAtTop = true;
                                 break;
                             case RfShowSelectionInDropDown.OnlyWhenNotInList:
-                                showAtTop = Items.Any(i => ItemComparer(i, selectedItem)) == false;
+                                showAtTop = Items == null || Items.Any(i => ItemComparer(i, selectedItem)) == false;
                                 break;
                         }
                     }


### PR DESCRIPTION
The same bug was fixed in the single dropdown. If items are null and there is a selected item then it will throw an exception.

#semver: patch

#34 closes