### PR TITLE
Feat/double click

### DIFF
--- a/docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Playgrounds/DoubleClickPage.razor
+++ b/docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Playgrounds/DoubleClickPage.razor
@@ -1,0 +1,82 @@
+﻿@page "/double-click/playground"
+@using RForge.Abstractions
+@rendermode InteractiveAuto
+
+<PlaygroundDetails @ref="Logger"
+                   PageSourceUrl="@RForgeHelpers.RepoDocsUrl("/RForgeDocs.Client/Pages/Playgrounds/DoubleClickPage.razor")"
+                   HasEvents=true
+                   SubTitle="Double Click"
+                   ComponentName="RfDoubleClick"
+                   Title="Playground"
+                   ComponentDetailsUrl="/double-click/details">
+
+    <Parameters>
+
+        <BulmaCheckbox Label="Has Click"
+                       HelpText="Adds a binding to OnClick if true.">
+            <InputCheckbox @bind-Value=HasClick class="checkbox" />
+        </BulmaCheckbox>
+        <BulmaCheckbox Label="Has Click"
+                       HelpText="Adds a binding to OnDoubleClick if true.">
+            <InputCheckbox @bind-Value=HasDoubleClick class="checkbox" />
+        </BulmaCheckbox>
+        <BulmaInput Label="Css Class"
+                    HelpText="Add a class to the root element.">
+            <InputText type="text" @bind-Value=@CssClass class="input" />
+        </BulmaInput>
+        <BulmaInput Label="Element"
+                    HelpText="The element tag. (span, button, a, div, etc.)">
+            <InputText type="text" @bind-Value=@Element class="input" />
+        </BulmaInput>
+        <BulmaInput Label="Child Content"
+                    HelpText="The content to show within the component.">
+            <InputText type="text" @bind-Value=@Content class="input" />
+        </BulmaInput>
+    </Parameters>
+
+    <Display>
+
+        @if (HasClick == true && HasDoubleClick == true)
+        {
+            <RfDoubleClick Element=@Element OnClick=OnClick OnDoubleClick=OnDoubleClick class="@CssClass">@Content</RfDoubleClick>
+        }
+        else if (HasClick == false && HasDoubleClick == true)
+        {
+            <RfDoubleClick Element=@Element OnDoubleClick=OnDoubleClick class="@CssClass">@Content</RfDoubleClick>
+        }
+        else if (HasClick == true && HasDoubleClick == false)
+        {
+            <RfDoubleClick Element=@Element OnClick=OnClick class="@CssClass">@Content</RfDoubleClick>
+        }
+        else
+        {
+            <RfDoubleClick Element=@Element class="@CssClass">@Content</RfDoubleClick>
+        }
+
+        <RfDoubleClick />
+
+    </Display>
+
+</PlaygroundDetails>
+
+
+@code {
+
+    public PlaygroundDetails Logger { get; set; }
+
+    public bool HasClick { get; set; }
+    public bool HasDoubleClick { get; set; }
+    public string CssClass { get; set; } = "button is-primary";
+    public string Content { get; set; } = "Click Me";
+
+    public string Element { get; set; } = "button";
+
+    public void OnClick()
+    {
+        Logger.AddLog("On Single Click");
+    }
+    public void OnDoubleClick()
+    {
+        Logger.AddLog("On Double Click");
+    }
+}

--- a/docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Playgrounds/DoubleClickPage.razor
+++ b/docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Playgrounds/DoubleClickPage.razor
@@ -13,10 +13,10 @@
     <Parameters>
 
         <BulmaCheckbox Label="Has Click"
-                       HelpText="Adds a binding to OnClick if true.">
+                       HelpText="Adds a binding to OnSingleClick if true.">
             <InputCheckbox @bind-Value=HasClick class="checkbox" />
         </BulmaCheckbox>
-        <BulmaCheckbox Label="Has Click"
+        <BulmaCheckbox Label="Has Double Click"
                        HelpText="Adds a binding to OnDoubleClick if true.">
             <InputCheckbox @bind-Value=HasDoubleClick class="checkbox" />
         </BulmaCheckbox>
@@ -32,25 +32,29 @@
                     HelpText="The content to show within the component.">
             <InputText type="text" @bind-Value=@Content class="input" />
         </BulmaInput>
+        <BulmaInput Label="Click Delay (ms)"
+                    HelpText="The delay in milliseconds to distinguish between single and double clicks.">
+            <InputNumber @bind-Value=@ClickDelay class="input" />
+        </BulmaInput>
     </Parameters>
 
     <Display>
 
         @if (HasClick == true && HasDoubleClick == true)
         {
-            <RfDoubleClick Element=@Element OnClick=OnClick OnDoubleClick=OnDoubleClick class="@CssClass">@Content</RfDoubleClick>
+            <RfDoubleClick Element=@Element OnSingleClick=OnClick OnDoubleClick=OnDoubleClick class="@CssClass" ClickDelay=ClickDelay>@Content</RfDoubleClick>
         }
         else if (HasClick == false && HasDoubleClick == true)
         {
-            <RfDoubleClick Element=@Element OnDoubleClick=OnDoubleClick class="@CssClass">@Content</RfDoubleClick>
+            <RfDoubleClick Element=@Element OnDoubleClick=OnDoubleClick class="@CssClass" ClickDelay=ClickDelay>@Content</RfDoubleClick>
         }
         else if (HasClick == true && HasDoubleClick == false)
         {
-            <RfDoubleClick Element=@Element OnClick=OnClick class="@CssClass">@Content</RfDoubleClick>
+            <RfDoubleClick Element=@Element OnSingleClick=OnClick class="@CssClass" ClickDelay=ClickDelay>@Content</RfDoubleClick>
         }
         else
         {
-            <RfDoubleClick Element=@Element class="@CssClass">@Content</RfDoubleClick>
+            <RfDoubleClick Element=@Element class="@CssClass" ClickDelay=ClickDelay>@Content</RfDoubleClick>
         }
 
         <RfDoubleClick />
@@ -64,10 +68,12 @@
 
     public PlaygroundDetails Logger { get; set; }
 
-    public bool HasClick { get; set; }
-    public bool HasDoubleClick { get; set; }
+    public bool HasClick { get; set; } = true;
+    public bool HasDoubleClick { get; set; } = true;
     public string CssClass { get; set; } = "button is-primary";
     public string Content { get; set; } = "Click Me";
+
+    public int ClickDelay { get; set; } = 400;
 
     public string Element { get; set; } = "button";
 
@@ -75,8 +81,8 @@
     {
         Logger.AddLog("On Single Click");
     }
-    public void OnDoubleClick()
+    public void OnDoubleClick(MouseEventArgs e)
     {
-        Logger.AddLog("On Double Click");
+        Logger.AddLog($"On Double Click");
     }
 }

--- a/docs/RForgeDocs/RForgeDocs/RForgeDocs/Components/Pages/ComponentDetail/DoubleClickPage.razor
+++ b/docs/RForgeDocs/RForgeDocs/RForgeDocs/Components/Pages/ComponentDetail/DoubleClickPage.razor
@@ -1,0 +1,31 @@
+﻿@page "/double-click/details"
+
+<ComponentDetail Title="Double Click"
+                 PlaygroundUrl="/double-click/playground"
+                 SubTitle="A double-click previewer">
+
+    <RepoLinks>
+        @ComponentDetail.SideLink(("RfDoubleClick.razor.cs", TagInfo.Razor, "https://github.com/Rumhyek/RForge/blob/main/src/RForge/RForgeBlazor/RfDoubleClick.razor.cs"))
+    </RepoLinks>
+
+    <Purpose>
+        <div class="content">
+            <p>
+                <code>RfDoubleClick</code> is a Blazor component that detects double-click events seperate from single-clicks.
+                It allows you to easily handle double-click interactions in your Blazor applications.
+            </p>
+        </div>
+    </Purpose>
+
+    <BasicUsage>
+        <div class="content">
+            
+        </div>
+    </BasicUsage>
+
+    <Setup>
+        <BasicSetupDetails />
+    </Setup>
+</ComponentDetail>
+
+

--- a/docs/RForgeDocs/RForgeDocs/RForgeDocs/Components/Pages/ComponentDetail/DoubleClickPage.razor
+++ b/docs/RForgeDocs/RForgeDocs/RForgeDocs/Components/Pages/ComponentDetail/DoubleClickPage.razor
@@ -19,7 +19,46 @@
 
     <BasicUsage>
         <div class="content">
+            <p>
+                <code>RfDoubleClick</code> creates an element based on <code>RfDoubleClick.Element</code>. It supports the following parameters:
+            </p>
+            <ul>
+                <li><code>OnDoubleClick</code>: Event callback for double-click events.</li>
+                <li><code>OnSingleClick</code>: Event callback for single-click events.</li>
+                <li><code>Element</code>: The HTML element to render (default is "button").</li>
+                <li><code>ClickDelay</code>: The delay in milliseconds to distinguish between single and double clicks. (default is 400)</li>
+                <li>Supports additional uncaptured parameters and applies them to the root element.</li>
+            </ul>
+
+            <p>
+                <code>RfDoubleClick</code> makes uses of onclick event exclusively for double-click detection over the use of ondblclick.
+                This should add better support for touch devices and other platforms that may not support the ondblclick event properly.
+            </p>
+
+            <h3>Example</h3>
+
+            <pre><code>&lt;RfDoubleClick OnSingleClick="@@OnSingleClick"
+               OnDoubleClick="@@OnDoubleClick"
+               Element="button"
+               class="button is-primary"&gt;
+    Click or Double Click Me
+&lt;/RfDoubleClick&gt;
             
+&lt;p&gt;@@message&lt;/p&gt;
+
+@@code {
+    private string message = "Try single or double clicking the button above.";
+
+    private void OnSingleClick()
+    {
+        message = "Single click detected!";
+    }
+
+    private void OnDoubleClick()
+    {
+        message = "Double click detected!";
+    }
+}</code></pre>
         </div>
     </BasicUsage>
 

--- a/docs/RForgeDocs/RForgeDocs/RForgeDocs/Components/Pages/ComponentDetail/DoubleClickPage.razor
+++ b/docs/RForgeDocs/RForgeDocs/RForgeDocs/Components/Pages/ComponentDetail/DoubleClickPage.razor
@@ -2,7 +2,7 @@
 
 <ComponentDetail Title="Double Click"
                  PlaygroundUrl="/double-click/playground"
-                 SubTitle="A double-click previewer">
+                 SubTitle="An easy way to capture double click events.">
 
     <RepoLinks>
         @ComponentDetail.SideLink(("RfDoubleClick.razor.cs", TagInfo.Razor, "https://github.com/Rumhyek/RForge/blob/main/src/RForge/RForgeBlazor/RfDoubleClick.razor.cs"))
@@ -12,7 +12,7 @@
         <div class="content">
             <p>
                 <code>RfDoubleClick</code> is a Blazor component that detects double-click events seperate from single-clicks.
-                It allows you to easily handle double-click interactions in your Blazor applications.
+                It allows you to easily handle single and double-click interactions from the same element in your Blazor applications.
             </p>
         </div>
     </Purpose>

--- a/docs/RForgeDocs/RForgeDocs/RForgeDocs/Components/Pages/ComponentsPage.razor
+++ b/docs/RForgeDocs/RForgeDocs/RForgeDocs/Components/Pages/ComponentsPage.razor
@@ -25,6 +25,7 @@
                             <p class="menu-label">General Components</p>
                             <ul class="menu-list">
                                 <li><a href="/context-menu/details">Context Menu</a></li>
+                                <li><a href="/double-click/details">Double Click</a></li>
                                 <li><a href="/markdown/details">Markdown</a></li>
                             </ul>
 

--- a/src/RForge/RForgeBlazor/RfDoubleClick.razor.cs
+++ b/src/RForge/RForgeBlazor/RfDoubleClick.razor.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace RForgeBlazor;
 
@@ -25,13 +26,13 @@ public class RfDoubleClick : ComponentBase
     /// Callback invoked on a single click.
     /// </summary>
     [Parameter]
-    public EventCallback OnSingleClick { get; set; }
+    public EventCallback<MouseEventArgs> OnSingleClick { get; set; }
 
     /// <summary>
     /// Callback invoked on a double click.
     /// </summary>
     [Parameter]
-    public EventCallback OnDoubleClick { get; set; }
+    public EventCallback<MouseEventArgs> OnDoubleClick { get; set; }
 
     /// <summary>
     /// The HTML element to render (e.g., "button", "div", "span"). 
@@ -75,7 +76,7 @@ public class RfDoubleClick : ComponentBase
         // Optimize if they don't provide a double click.
         if (OnDoubleClick.HasDelegate == true)
         {
-            builder.AddAttribute(2, "onclick", EventCallback.Factory.Create(this, OnClickAndDoubleClick));
+            builder.AddAttribute(2, "onclick", EventCallback.Factory.Create<MouseEventArgs>(this, OnClickAndDoubleClick));
         }
         else
         {
@@ -91,7 +92,7 @@ public class RfDoubleClick : ComponentBase
     /// Handles click and double click logic, invoking the appropriate callback.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    private async Task OnClickAndDoubleClick()
+    private async Task OnClickAndDoubleClick(MouseEventArgs e)
     {
         currentClickCount++;
 
@@ -105,7 +106,7 @@ public class RfDoubleClick : ComponentBase
                 // Reset this back to 0 after this has fired.
                 currentClickCount = 0;
 
-                await OnSingleClick.InvokeAsync();
+                await OnSingleClick.InvokeAsync(e);
             }
             else
             {
@@ -116,7 +117,7 @@ public class RfDoubleClick : ComponentBase
         else if (currentClickCount >= 2)
         {
             // Double click
-            await OnDoubleClick.InvokeAsync();
+            await OnDoubleClick.InvokeAsync(e);
             currentClickCount = 0;
         }
     }

--- a/src/RForge/RForgeBlazor/RfDoubleClick.razor.cs
+++ b/src/RForge/RForgeBlazor/RfDoubleClick.razor.cs
@@ -9,7 +9,7 @@ namespace RForgeBlazor;
 /// </summary>
 /// <example>
 /// <code>
-/// <RfDoubleClick OnClick="HandleClick" OnDoubleClick="HandleDoubleClick" Element="button">
+/// <RfDoubleClick OnSingleClick="HandleClick" OnDoubleClick="HandleDoubleClick" Element="button">
 ///     Click or Double Click Me
 /// </RfDoubleClick>
 ///
@@ -25,7 +25,7 @@ public class RfDoubleClick : ComponentBase
     /// Callback invoked on a single click.
     /// </summary>
     [Parameter]
-    public EventCallback OnClick { get; set; }
+    public EventCallback OnSingleClick { get; set; }
 
     /// <summary>
     /// Callback invoked on a double click.
@@ -74,9 +74,13 @@ public class RfDoubleClick : ComponentBase
 
         // Optimize if they don't provide a double click.
         if (OnDoubleClick.HasDelegate == true)
+        {
             builder.AddAttribute(2, "onclick", EventCallback.Factory.Create(this, OnClickAndDoubleClick));
+        }
         else
-            builder.AddAttribute(2, "onclick", OnClick);
+        {
+            builder.AddAttribute(2, "onclick", OnSingleClick);
+        }
 
         builder.AddContent(4, ChildContent);
 
@@ -91,16 +95,23 @@ public class RfDoubleClick : ComponentBase
     {
         currentClickCount++;
 
-        // If this was clicked only once then fire off OnClick.
-        if (currentClickCount == 1 && OnClick.HasDelegate == true)
+        // If this was clicked only once then fire off OnSingleClick.
+        if (currentClickCount == 1)
         {
             await Task.Delay(ClickDelay);
 
-            if (currentClickCount == 1)
-                await OnClick.InvokeAsync();
+            if (currentClickCount == 1 && OnSingleClick.HasDelegate == true)
+            {
+                // Reset this back to 0 after this has fired.
+                currentClickCount = 0;
 
-            // Reset this back to 0 after this has fired.
-            currentClickCount = 0;
+                await OnSingleClick.InvokeAsync();
+            }
+            else
+            {
+                // Reset this back to 0 after this has fired.
+                currentClickCount = 0;
+            }
         }
         else if (currentClickCount >= 2)
         {

--- a/src/RForge/RForgeBlazor/RfDoubleClick.razor.cs
+++ b/src/RForge/RForgeBlazor/RfDoubleClick.razor.cs
@@ -42,10 +42,10 @@ public class RfDoubleClick : ComponentBase
 
     /// <summary>
     /// The delay in milliseconds to distinguish between single and double clicks.
-    /// Default is 250ms.
+    /// Default is 400ms.
     /// </summary>
     [Parameter]
-    public int ClickDelay { get; set; } = 250;
+    public int ClickDelay { get; set; } = 400;
 
     /// <summary>
     /// The content to be rendered inside the element.

--- a/src/RForge/RForgeBlazor/RfDoubleClick.razor.cs
+++ b/src/RForge/RForgeBlazor/RfDoubleClick.razor.cs
@@ -1,0 +1,114 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace RForgeBlazor;
+
+
+/// <summary>
+/// A Blazor component that distinguishes between single and double clicks on an element.
+/// </summary>
+/// <example>
+/// <code>
+/// <RfDoubleClick OnClick="HandleClick" OnDoubleClick="HandleDoubleClick" Element="button">
+///     Click or Double Click Me
+/// </RfDoubleClick>
+///
+/// @code {
+///     private void HandleClick() { /* Single click logic */ }
+///     private void HandleDoubleClick() { /* Double click logic */ }
+/// }
+/// </code>
+/// </example>
+public class RfDoubleClick : ComponentBase
+{
+    /// <summary>
+    /// Callback invoked on a single click.
+    /// </summary>
+    [Parameter]
+    public EventCallback OnClick { get; set; }
+
+    /// <summary>
+    /// Callback invoked on a double click.
+    /// </summary>
+    [Parameter]
+    public EventCallback OnDoubleClick { get; set; }
+
+    /// <summary>
+    /// The HTML element to render (e.g., "button", "div", "span"). 
+    /// Default is "button".
+    /// </summary>
+    [Parameter]
+    public string Element { get; set; } = "button";
+
+    /// <summary>
+    /// The delay in milliseconds to distinguish between single and double clicks.
+    /// Default is 250ms.
+    /// </summary>
+    [Parameter]
+    public int ClickDelay { get; set; } = 250;
+
+    /// <summary>
+    /// The content to be rendered inside the element.
+    /// </summary>
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
+
+    /// <summary>
+    /// Additional attributes to be applied to the rendered element.
+    /// </summary>
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object> Attributes { get; set; }
+
+    private int currentClickCount = 0;
+
+    /// <summary>
+    /// Builds the render tree for the component.
+    /// </summary>
+    /// <param name="builder">The <see cref="RenderTreeBuilder"/> used to build the component's render tree.</param>
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        base.BuildRenderTree(builder);
+
+        builder.OpenElement(0, Element);
+        builder.AddMultipleAttributes(1, Attributes);
+
+        // Optimize if they don't provide a double click.
+        if (OnDoubleClick.HasDelegate == true)
+            builder.AddAttribute(2, "onclick", EventCallback.Factory.Create(this, OnClickAndDoubleClick));
+        else
+            builder.AddAttribute(2, "onclick", OnClick);
+
+        builder.AddContent(4, ChildContent);
+
+        builder.CloseElement();
+    }
+
+    /// <summary>
+    /// Handles click and double click logic, invoking the appropriate callback.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    private async Task OnClickAndDoubleClick()
+    {
+        currentClickCount++;
+
+        // If this was clicked only once then fire off OnClick.
+        if (currentClickCount == 1 && OnClick.HasDelegate == true)
+        {
+            await Task.Delay(ClickDelay);
+
+            if (currentClickCount == 1)
+                await OnClick.InvokeAsync();
+
+            // Reset this back to 0 after this has fired.
+            currentClickCount = 0;
+        }
+        else if (currentClickCount >= 2)
+        {
+            // Double click
+            await OnDoubleClick.InvokeAsync();
+            currentClickCount = 0;
+        }
+    }
+}
+
+

--- a/src/RForge/RForgeTest/RForgeTest.Client/Pages/DoubleClick.razor
+++ b/src/RForge/RForgeTest/RForgeTest.Client/Pages/DoubleClick.razor
@@ -1,0 +1,31 @@
+﻿@page "/double-click"
+@rendermode InteractiveAuto
+
+<PageTitle>Double Click</PageTitle>
+
+<h1>Double Click</h1>
+
+<p role="status">Current count: @currentCount</p>
+<div>
+    Click once for 1 twice for 10.
+</div>
+
+<div>
+    <RfDoubleClick class="button is-primary" OnClick="IncrementCount" OnDoubleClick="IncrementDoubleCount">Click Me</RfDoubleClick>
+</div>
+
+<RfDoubleClick class="button is-primary" OnClick="IncrementCount" OnDoubleClick="IncrementDoubleCount" Element="a">A TAG</RfDoubleClick>
+
+@code {
+    private int currentCount = 0;
+
+    private void IncrementCount()
+    {
+        currentCount++;
+    }
+
+    private void IncrementDoubleCount()
+    {
+        currentCount += 10;
+    }
+}

--- a/src/RForge/RForgeTest/RForgeTest.Client/Pages/DoubleClick.razor
+++ b/src/RForge/RForgeTest/RForgeTest.Client/Pages/DoubleClick.razor
@@ -11,12 +11,12 @@
 </div>
 
 <div>
-    <RfDoubleClick class="button is-primary" OnClick="IncrementCount" OnDoubleClick="IncrementDoubleCount">Click Me</RfDoubleClick>
+    <RfDoubleClick class="button is-primary" OnSingleClick="IncrementCount" OnDoubleClick="IncrementDoubleCount">Click Me</RfDoubleClick>
 </div>
 
-<RfDoubleClick class="button is-primary" OnClick="IncrementCount" OnDoubleClick="IncrementDoubleCount" Element="a">A TAG</RfDoubleClick>
+<RfDoubleClick class="button is-primary" OnSingleClick="IncrementCount" OnDoubleClick="IncrementDoubleCount" Element="a">A TAG</RfDoubleClick>
 <br />
-<RfDoubleClick class="button is-primary" OnClick="IncrementCount" Element="div">SINGLE CLICK ONLY</RfDoubleClick>
+<RfDoubleClick class="button is-primary" OnSingleClick="IncrementCount" Element="div">SINGLE CLICK ONLY</RfDoubleClick>
 <br />
 <RfDoubleClick class="button is-primary" OnDoubleClick="IncrementDoubleCount" Element="div">DOUBLE CLICK ONLY</RfDoubleClick>
 

--- a/src/RForge/RForgeTest/RForgeTest.Client/Pages/DoubleClick.razor
+++ b/src/RForge/RForgeTest/RForgeTest.Client/Pages/DoubleClick.razor
@@ -15,6 +15,10 @@
 </div>
 
 <RfDoubleClick class="button is-primary" OnClick="IncrementCount" OnDoubleClick="IncrementDoubleCount" Element="a">A TAG</RfDoubleClick>
+<br />
+<RfDoubleClick class="button is-primary" OnClick="IncrementCount" Element="div">SINGLE CLICK ONLY</RfDoubleClick>
+<br />
+<RfDoubleClick class="button is-primary" OnDoubleClick="IncrementDoubleCount" Element="div">DOUBLE CLICK ONLY</RfDoubleClick>
 
 @code {
     private int currentCount = 0;

--- a/src/RForge/RForgeTest/RForgeTest/Components/Layout/NavMenu.razor
+++ b/src/RForge/RForgeTest/RForgeTest/Components/Layout/NavMenu.razor
@@ -32,10 +32,14 @@
                 Dialog
             </NavLink>
 
+            <NavLink class="navbar-item" href="double-click">
+                Double Click
+            </NavLink>
+
             <NavLink class="navbar-item" href="dropdown">
                 Drop Down
             </NavLink>
-            
+
             <NavLink class="navbar-item" href="markdown">
                 Markdown
             </NavLink>


### PR DESCRIPTION
This pull request introduces a new Blazor component, `RfDoubleClick`, designed to handle both single and double-click events with customizable behavior. It also includes integration of this component into the documentation, test pages, and navigation menus. Below is a summary of the most important changes grouped by theme:

### New Component Implementation:
* Added the `RfDoubleClick` component in `src/RForge/RForgeBlazor/RfDoubleClick.razor.cs`. This component distinguishes between single and double clicks, supports customizable HTML elements, and allows configuring the click delay. It also includes attributes for additional customization and logic to handle click events.

### Documentation Updates:
* Created a new playground page (`DoubleClickPage.razor`) to demonstrate the `RfDoubleClick` component with interactive parameter adjustments.
* Added a detailed documentation page (`DoubleClickPage.razor`) explaining the purpose, usage, and example code for the `RfDoubleClick` component.
* Updated the components list in `ComponentsPage.razor` to include the new `Double Click` component.

### Test Page and Navigation Integration:
* Added a test page (`DoubleClick.razor`) to verify the functionality of the `RfDoubleClick` component with various configurations, including single-click only, double-click only, and both.
* Updated the navigation menu (`NavMenu.razor`) to include a link to the `Double Click` test page.