### PR TITLE
Feat/data grid keep selection

### DIFF
--- a/docs/RForgeDocs/RForgeDocs.Abstractions/DataModels/UserDataGridFilterData.cs
+++ b/docs/RForgeDocs/RForgeDocs.Abstractions/DataModels/UserDataGridFilterData.cs
@@ -3,6 +3,8 @@
 public class UserDataGridFilterData
 {
     public int? Id { get; set; }
+    public List<int> Ids { get; set; }
+
     public string FullName { get; set; }
     public string FirstName { get; set; }
     public string LastName { get; set; }

--- a/docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Examples/DataGrid/ViewSelectedPage.razor
+++ b/docs/RForgeDocs/RForgeDocs/RForgeDocs.Client/Pages/Examples/DataGrid/ViewSelectedPage.razor
@@ -1,0 +1,195 @@
+﻿@page "/data-grid/example/view-selected-example"
+
+@using RForge.Abstractions
+@using RForgeDocs.Abstractions
+@using RForgeDocs.Abstractions.DataModels
+@using RForgeDocs.Abstractions.Services
+
+@inject IUserDataGridPageProcessor userDataGridPageProcessor
+
+@rendermode InteractiveAuto
+
+<ExampleDetail Title="View Selected Only"
+               SubTitle="Shows a way to toggle viewing all selected."
+               ComponentName="Data Grid"
+               PageSourceUrl="@RForgeHelpers.RepoDocsUrl("/RForgeDocs.Client/Pages/Examples/DataGrid/ViewSelectedPage.razor")"
+               ComponentDetailsUrl="/data-grid/details" />
+
+<div class="columns">
+    <div class="column is-4">
+        <article class="section">
+            <div class="box">
+                <div class="content">
+                    <p>
+                        This example shows how to toggle between viewing all users and only the selected users in a data grid.
+                        It does this by maintaining two sets of settings: one for the default view (all users) and one for the selected view (only selected users) and 
+                        adding an additional filter option <code>Ids</code>.
+                    </p>
+                    <p>
+                        The "View Selected Users" button will show only the users that are currently selected, while the "View All Users" button will reset the view to show all users.
+                    </p>
+                    <p>
+                        The data grid supports filtering, sorting, and pagination. You can also clear filters and selection using the provided buttons.
+                    </p>
+                </div>
+            </div>
+        </article>
+    </div>
+    <div class="column">
+        <article class="section">
+
+            <div class="buttons">
+                <a class="button"
+                   @onclick=ClearFilters>
+                    Clear Filters
+                </a> 
+                <a class="button"
+                        @onclick=ClearSelection>
+                    Clear Selection
+                </a>
+                @if (IsDefaultSettings == true)
+                {
+                    <a class="button is-primary"
+                       @onclick="async () => await UpdateSettings(SelectedSettings)">
+                        View Selected Users
+                    </a>
+                }
+                else
+                {
+                    <a class="button is-primary"
+                       @onclick="async () => await UpdateSettings(DefaultSettings)">
+                        View All Users
+                    </a>
+                }
+
+
+            </div>
+
+            <RfDataGrid TRowData="UserData"
+                        Data=CurrentSettings.Data
+                        @bind-CurrentPageIndex=@CurrentSettings.CurrentPageIndex
+                        @bind-SortKey=@CurrentSettings.CurrentSortKey
+                        @bind-SortOrder=@CurrentSettings.CurrentSortOrder
+                        PageSize=@CurrentSettings.PageSize
+                        TotalCount=@CurrentSettings.TotalCount
+                        KeepSelection=true
+                        AllowSelection=true
+                        @bind-CurrentSelection=CurrentSelection
+                        RowComparer=@((r1, r2) => r1.Id == r2.Id)
+                        OnLoadData=OnLoad>
+
+                <Headers>
+
+                    <RfDgHeader AllowSorting=false>Id</RfDgHeader>
+                    <RfDgHeader SortKey="FirstName">First Name</RfDgHeader>
+                    <RfDgHeader SortKey="LastName">Last Name</RfDgHeader>
+                    <RfDgHeader SortKey="IsAdmin">Is Admin</RfDgHeader>
+
+                </Headers>
+
+                <Filters>
+                    <RfDgFilterInputInt @bind-Value=CurrentSettings.Filters.Id MinValue=0 />
+                    <RfDgFilterInputText @bind-Value=CurrentSettings.Filters.FirstName Placeholder="Contains" />
+                    <RfDgFilterNone />
+                    <RfDgFilterInputBool @bind-Value=CurrentSettings.Filters.IsAdmin Placeholder="True / False" />
+                </Filters>
+
+                <Cells>
+                    <td>@context.Id</td>
+                    <td>@context.FirstName</td>
+                    <td>@context.LastName</td>
+                    <td>@context.IsAdmin</td>
+                </Cells>
+
+                <EmptyContent>
+
+                    <td colspan="4">No users were found with the current search results.</td>
+
+                </EmptyContent>
+
+            </RfDataGrid>
+
+        </article>
+    </div>
+</div>
+
+@code {
+    private List<UserData> CurrentSelection { get; set; } = new();
+
+    private DataGridSettingsData DefaultSettings { get; set; } = new();
+    private DataGridSettingsData SelectedSettings { get; set; } = new();
+    private DataGridSettingsData CurrentSettings { get; set; }
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        CurrentSettings = DefaultSettings;
+    }
+
+    private bool IsDefaultSettings => CurrentSettings == DefaultSettings;
+
+    public async Task OnLoad()
+    {
+        var filters = new UserDataGridFilterData()
+        {
+            Id = CurrentSettings.Filters.Id,
+            IsAdmin = CurrentSettings.Filters.IsAdmin,
+            FirstName = CurrentSettings.Filters.FirstName,
+        };
+
+        if (CurrentSettings == SelectedSettings)
+            filters.Ids = CurrentSelection.Select(u => u.Id).ToList();
+
+        var response = await userDataGridPageProcessor.GetPage(new UserDataGridGetPageData()
+        {
+            Filters = filters,
+            PageIndex = CurrentSettings.CurrentPageIndex,
+            SortKey = CurrentSettings.CurrentSortKey,
+            PageSize = CurrentSettings.PageSize,
+            SortOrder = CurrentSettings.CurrentSortOrder
+        });
+
+        CurrentSettings.Data = response.Data;
+        CurrentSettings.TotalCount = response.TotalCount;
+    }
+
+    private async Task UpdateSettings(DataGridSettingsData settings)
+    {
+        CurrentSettings = settings;
+        await OnLoad();
+    }
+
+    private async Task ClearFilters()
+    {
+        CurrentSettings.Filters = new();
+        await OnLoad();
+    }
+
+    private async Task ClearSelection()
+    {
+        CurrentSelection.Clear();
+        await OnLoad();
+    }
+
+    private class FilterData
+    {
+        public int? Id { get; set; }
+        public string FirstName { get; set; }
+        public bool? IsAdmin { get; set; }
+
+    }
+
+    
+
+    private class DataGridSettingsData
+    {
+        public int TotalCount { get; set; }
+        public int PageSize { get; set; } = 10;
+        public int CurrentPageIndex { get; set; }
+        public string CurrentSortKey { get; set; }
+        public RfSortOrder CurrentSortOrder { get; set; }
+        public FilterData Filters { get; set; } = new();
+        public List<UserData> Data { get; set; }
+    }
+
+}

--- a/docs/RForgeDocs/RForgeDocs/RForgeDocs/Components/Pages/ComponentDetail/DataGridPage.razor
+++ b/docs/RForgeDocs/RForgeDocs/RForgeDocs/Components/Pages/ComponentDetail/DataGridPage.razor
@@ -79,6 +79,7 @@
             <ul class="menu-list">
                 @ComponentDetail.SideLink(("Basic Example", TagInfo.Empty, "/data-grid/example/basic-example"))
                 @ComponentDetail.SideLink(("Double Click", TagInfo.Empty, "/data-grid/example/double-click"))
+                @ComponentDetail.SideLink(("View Selected Only", TagInfo.Empty, "/data-grid/example/view-selected-example"))
 
             </ul>
         </div>

--- a/docs/RForgeDocs/RForgeDocsLibrary/Implementation/UserDataGridPageProcessor.cs
+++ b/docs/RForgeDocs/RForgeDocsLibrary/Implementation/UserDataGridPageProcessor.cs
@@ -21,6 +21,9 @@ public class UserDataGridPageProcessor : IUserDataGridPageProcessor
         if (options.Filters.Id.HasValue == true)
             query = query.Where(u => u.Id == options.Filters.Id.Value);
         
+        if(options.Filters.Ids != null)
+            query = query.Where(u => options.Filters.Ids.Contains(u.Id));
+
         if (options.Filters.IsAdmin.HasValue == true)
             query = query.Where(u => u.IsAdmin == options.Filters.IsAdmin.Value);
 

--- a/src/RForge/RForgeBlazor/RfDataGrid.razor
+++ b/src/RForge/RForgeBlazor/RfDataGrid.razor
@@ -103,18 +103,18 @@
                     @foreach (var row in Data)
                     {
                         var rowCss = "";
-                        if (AllowSelection == true && currentSelection.Contains(row) == true)
+                        if (CurrentSelection.Any(selectedRow => RowComparer(selectedRow, row)) == true)
                         {
-                            rowCss += "selected is-primary";
+                            rowCss += $"selected {SelectedRowCssClass}".Trim();
                         }
 
                         @if (OnRowDoubleClick.HasDelegate == true)
                         {
-                            <RfDoubleClick Element="tr" 
-                                class="@rowCss"
-                                OnSingleClick=@(async () => await onRowClick(row))
-                                OnDoubleClick=@(async () => await onRowDoubleClick(row))
-                                ClickDelay=@DoubleClickDelay>
+                            <RfDoubleClick Element="tr"
+                                           class="@rowCss"
+                                           OnSingleClick=@(async () => await onRowClick(row))
+                                           OnDoubleClick=@(async () => await onRowDoubleClick(row))
+                                           ClickDelay=@DoubleClickDelay>
                                 @Cells(row)
                             </RfDoubleClick>
                         }
@@ -143,35 +143,40 @@
                 {
                     var pagingTabs = PagingTabs;
                     <div class="is-flex">
-                        <div class="button" @onclick="@OnFirstPageClick">
+                        <div class="button"
+                             @onclick="@OnFirstPageClick"
+                             title="First Page"
+                             disabled=@(CurrentPageIndex == 0)>
                             <span class="icon">
                                 <i class="fa-solid fa-angles-left"></i>
                             </span>
                         </div>
-                        <div class="button" @onclick="@OnPreviousPageClick">
+                        <div class="button" @onclick="@OnPreviousPageClick"
+                             title="Previous Page"
+                             disabled=@(CurrentPageIndex == 0)>
                             <span class="icon">
                                 <i class="fa-solid fa-angle-left"></i>
                             </span>
                         </div>
                         @foreach (var pageIndex in pagingTabs)
                         {
-                            string css = null;
-                            if (pageIndex == CurrentPageIndex)
-                            {
-                                css = "is-primary";
-                            }
-
-                            <div class="button @css" @onclick=@(async () => await OnPageIndexClick(pageIndex))>
+                            <div class="button @Rf.ClassWhen((CurrentPagingCssClass, pageIndex == CurrentPageIndex))"
+                                 @onclick=@(async () => await OnPageIndexClick(pageIndex))>
                                 @(pageIndex + 1)
                             </div>
-
                         }
-                        <div class="button" @onclick="@OnNextPageClick">
+                        <div class="button"
+                             @onclick="@OnNextPageClick"
+                             title="Next Page"
+                             disabled=@(CurrentPageIndex + 1 == TotalPages)>
                             <span class="icon">
                                 <i class="fa-solid fa-angle-right"></i>
                             </span>
                         </div>
-                        <div class="button" @onclick="@OnLastPageClick">
+                        <div class="button"
+                             @onclick="@OnLastPageClick"
+                             title="Last Page"
+                             disabled=@(CurrentPageIndex + 1 == TotalPages)>
                             <span class="icon">
                                 <i class="fa-solid fa-angles-right"></i>
                             </span>

--- a/src/RForge/RForgeBlazor/RfDataGrid.razor
+++ b/src/RForge/RForgeBlazor/RfDataGrid.razor
@@ -103,7 +103,7 @@
                     @foreach (var row in Data)
                     {
                         var rowCss = "";
-                        if (CurrentSelection.Any(selectedRow => RowComparer(selectedRow, row)) == true)
+                        if (CurrentSelection?.Any(selectedRow => RowComparer(selectedRow, row)) == true)
                         {
                             rowCss += $"selected {SelectedRowCssClass}".Trim();
                         }

--- a/src/RForge/RForgeBlazor/RfDataGrid.razor.cs
+++ b/src/RForge/RForgeBlazor/RfDataGrid.razor.cs
@@ -41,7 +41,6 @@ public partial class RfDataGrid<TRowData>
     [Parameter]
     public int? PreRenderRowCount { get; set; }
 
-
     /// <summary>
     /// If true shows the filter row.
     /// </summary>
@@ -117,10 +116,15 @@ public partial class RfDataGrid<TRowData>
     public EventCallback<int?> PageSizeChanged { get; set; }
 
     /// <summary>
-    /// The max paging options to show in the bottom left. By default = 7
+    /// The max paging options to show in the bottom left. By default = 0
     /// </summary>
     [Parameter]
-    public int MaxPagingOptions { get; set; } = 7;
+    public int MaxPagingOptions { get; set; } = 0;
+
+    /// <summary>
+    /// Gets or sets the CSS class applied to the current page in a pagination control. Default is "is-primary".
+    /// </summary>
+    public string CurrentPagingCssClass { get; set; } = "is-primary";
 
     /// <summary>
     /// Fires when a row is selected return the value of the row.
@@ -211,18 +215,47 @@ public partial class RfDataGrid<TRowData>
     /// </summary>
     [Parameter]
     public bool IsFullWidth { get; set; } = true;
-    #endregion
+
+    /// <summary>
+    /// If true the selection will be kept when the data is reloaded. Default = false.
+    /// </summary>
+    [Parameter]
+    public bool KeepSelection { get; set; } = false;
 
     /// <summary>
     /// The current selection of rows.
     /// </summary>
-    private List<TRowData> currentSelection { get; set; } = new List<TRowData>();
+    [Parameter]
+    public List<TRowData> CurrentSelection { get; set; } = new List<TRowData>();
+
+    /// <summary>
+    /// Fires when the current selection changes.
+    /// </summary>
+    [Parameter]
+    public EventCallback<List<TRowData>> CurrentSelectionChanged { get; set; }
+
+
+    /// <summary>  
+    /// Used to compare two rows to determine if they are the same. If not set, it will use <see cref="object.Equals(object?)"/> to compare the two rows.  
+    /// </summary>  
+    [Parameter]
+    public Func<TRowData, TRowData, bool> RowComparer { get; set; } 
+
+    /// <summary>
+    /// Adds a css class to the selected row. Default = "is-primary".
+    /// </summary>
+    [Parameter]
+    public string SelectedRowCssClass { get; set; } = "is-primary";
+    #endregion
+
+
+    private readonly Func<TRowData, TRowData, bool> _defaultRowComparer = (i1, i2) => i1.Equals(i2);
 
     /// <summary>
     /// The context for the data grid. Used to talk between the data grid and the children.
     /// </summary>
     private DataGridContext GridContext { get; set; }
-    
+
     /// <summary>
     /// If the sort order or key has been updated.
     /// </summary>
@@ -243,19 +276,29 @@ public partial class RfDataGrid<TRowData>
             string css = "table";
 
             if (string.IsNullOrEmpty(CssClass) == false)
+            {
                 css += $" {CssClass}";
+            }
 
             if (IsFullWidth == true)
+            {
                 css += " is-fullwidth";
+            }
 
             if (AllowFilters == true && Filters != null)
+            {
                 css += " has-filters";
+            }
 
-            if (AllowSelection == true && Cells != null && Data != null)
-                css += " is-hoverable";
+            if ((AllowSelection == true || OnRowDoubleClick.HasDelegate == true || OnRowClick.HasDelegate == true) && Cells != null && Data != null)
+            {
+                css += " is-hoverable is-clickable";
+            }
 
             if (IsStriped == true)
+            {
                 css += " is-striped";
+            }
 
             return css;
         }
@@ -268,10 +311,15 @@ public partial class RfDataGrid<TRowData>
     {
         get
         {
-            if (PageSize == null && PreRenderRowCount == null) return 4;
+            if (PageSize == null && PreRenderRowCount == null)
+            {
+                return 4;
+            }
 
             if (PreRenderRowCount == null)
+            {
                 return PageSize.Value;
+            }
 
             return PreRenderRowCount.Value;
         }
@@ -282,11 +330,18 @@ public partial class RfDataGrid<TRowData>
     /// </summary>
     public async Task ReloadData()
     {
-        while (currentSelection.Count > 0)
+        if (KeepSelection == false)
         {
-            var removed = currentSelection[currentSelection.Count - 1];
-            currentSelection.RemoveAt(currentSelection.Count - 1);
-            await this.OnRowDeselect.InvokeAsync(removed);
+            bool hasChanged = CurrentSelection.Count > 0;
+            while (CurrentSelection.Count > 0)
+            {
+                var removed = CurrentSelection[CurrentSelection.Count - 1];
+                CurrentSelection.RemoveAt(CurrentSelection.Count - 1);
+                await this.OnRowDeselect.InvokeAsync(removed);
+            }
+
+            if (hasChanged == true)
+                await CurrentSelectionChanged.InvokeAsync(CurrentSelection);
         }
 
         await OnLoadData.InvokeAsync();
@@ -304,6 +359,7 @@ public partial class RfDataGrid<TRowData>
         };
         GridContext.OnSortChanged += OnSortChangedCallback;
         GridContext.OnFilterChanged += OnFilterChangedCallback;
+        RowComparer ??= _defaultRowComparer; //if not set use the default comparer
     }
 
     /// <summary>
@@ -372,6 +428,9 @@ public partial class RfDataGrid<TRowData>
                 case nameof(MaxPagingOptions):
                     MaxPagingOptions = (int)parameter.Value;
                     break;
+                case nameof(CurrentPagingCssClass):
+                    CurrentPagingCssClass = (string)parameter.Value;
+                    break;
                 case nameof(OnRowSelect):
                     OnRowSelect = (EventCallback<TRowData>)parameter.Value;
                     break;
@@ -389,6 +448,19 @@ public partial class RfDataGrid<TRowData>
                     break;
                 case nameof(OnLoadData):
                     OnLoadData = (EventCallback)parameter.Value;
+                    break;
+                case nameof(CurrentSelection):
+                    CurrentSelection = (List<TRowData>)parameter.Value;
+                    break;
+                case nameof(SelectedRowCssClass):
+                    SelectedRowCssClass = (string)parameter.Value;
+                    break;
+                case nameof(KeepSelection):
+                    KeepSelection = (bool)parameter.Value;
+                    break;
+                case nameof(RowComparer):
+                    RowComparer = (Func<TRowData, TRowData, bool>)parameter.Value;
+                    RowComparer ??= _defaultRowComparer; //if not set use the default comparer
                     break;
                 case nameof(Headers):
                     Headers = (RenderFragment)parameter.Value;
@@ -436,7 +508,7 @@ public partial class RfDataGrid<TRowData>
     /// <returns></returns>
     protected override async Task OnParametersSetAsync()
     {
-        if(onParameterSetUpdateSortOrder == true)
+        if (onParameterSetUpdateSortOrder == true)
         {
             //The parent component updated the parameter. Notify the children
             await GridContext.SortChanged(new DataGridSortBy()
@@ -446,8 +518,10 @@ public partial class RfDataGrid<TRowData>
             });
         }
 
-        if(onParameterSetReloadData == true)
+        if (onParameterSetReloadData == true)
+        {
             await OnLoadData.InvokeAsync();
+        }
     }
 
     /// <summary>
@@ -456,7 +530,9 @@ public partial class RfDataGrid<TRowData>
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender == true && Data == null)
+        {
             await ReloadData();
+        }
     }
 
     #region paging
@@ -473,7 +549,10 @@ public partial class RfDataGrid<TRowData>
     {
         get
         {
-            if (ShowPaging == false) return 0;
+            if (ShowPaging == false)
+            {
+                return 0;
+            }
 
             return (int)Math.Ceiling(TotalCount / (decimal)PageSize.Value);
         }
@@ -486,7 +565,10 @@ public partial class RfDataGrid<TRowData>
     {
         get
         {
-            if (ShowPaging == false) return null;
+            if (ShowPaging == false)
+            {
+                return null;
+            }
 
             int totalPages = TotalPages;
             int[] pageIndexes = new int[Math.Min(totalPages, MaxPagingOptions)];
@@ -545,7 +627,10 @@ public partial class RfDataGrid<TRowData>
     /// <param name="pageIndex">The page index to navigate to.</param>
     public async Task OnPageIndexClick(int pageIndex)
     {
-        if (pageIndex == CurrentPageIndex) return;
+        if (pageIndex == CurrentPageIndex)
+        {
+            return;
+        }
 
         CurrentPageIndex = pageIndex;
         await CurrentPageIndexChanged.InvokeAsync(pageIndex);
@@ -569,22 +654,22 @@ public partial class RfDataGrid<TRowData>
             return;
         }
 
-        if (currentSelection.Contains(row) == true)
+        if (CurrentSelection.Contains(row) == true)
         {
-            currentSelection.Remove(row);
+            CurrentSelection.Remove(row);
             await OnRowDeselect.InvokeAsync(row);
             await OnRowClick.InvokeAsync(row);
         }
         else
         {
-            if (MaxSelection != null && currentSelection.Count + 1 > MaxSelection)
+            if (MaxSelection != null && CurrentSelection.Count + 1 > MaxSelection)
             {
-                var deselectFirst = currentSelection.First();
-                currentSelection.RemoveAt(0);
+                var deselectFirst = CurrentSelection.First();
+                CurrentSelection.RemoveAt(0);
                 await OnRowDeselect.InvokeAsync(deselectFirst);
             }
 
-            currentSelection.Add(row);
+            CurrentSelection.Add(row);
             await OnRowSelect.InvokeAsync(row);
             await OnRowClick.InvokeAsync(row);
         }
@@ -605,7 +690,9 @@ public partial class RfDataGrid<TRowData>
     private async Task OnFilterChangedCallback(object caller, DataGridFilterBy filter)
     {
         if (ShowPaging == true && CurrentPageIndex != 0)
+        {
             await CurrentPageIndexChanged.InvokeAsync(0);
+        }
 
         await ReloadData();
     }

--- a/src/RForge/RForgeBlazor/RfDataGrid.razor.css
+++ b/src/RForge/RForgeBlazor/RfDataGrid.razor.css
@@ -1,0 +1,4 @@
+﻿
+.is-clickable {
+    cursor: pointer;
+}


### PR DESCRIPTION
This pull request introduces enhancements to the `RfDataGrid` component and its associated files, focusing on improving functionality, user experience, and maintainability. Key changes include the addition of new filtering capabilities, better selection handling, pagination improvements, and the integration of a new example page for viewing selected rows in the data grid.

### Enhancements to `RfDataGrid` functionality:

* **Selection Handling**: Added support for maintaining row selection when data is reloaded (`KeepSelection` parameter), customizable CSS classes for selected rows (`SelectedRowCssClass`), and a `RowComparer` parameter for custom row comparison logic. These changes improve flexibility and user experience when interacting with the data grid. (`[[1]](diffhunk://#diff-ad0e49ae757bb938550f20f6cc753a5e2f1998572bbd6d22500ae81b60e37f1fL214-R252)`, `[[2]](diffhunk://#diff-ad0e49ae757bb938550f20f6cc753a5e2f1998572bbd6d22500ae81b60e37f1fR454-R470)`, `[[3]](diffhunk://#diff-e2149e8979998fe75778339f1e0452d39d315200441593c8c1f5ac23b6da3cc5L106-R108)`)
* **Pagination Improvements**: Enhanced pagination controls with tooltips, disabled states for edge cases (e.g., first/last page), and customizable CSS classes for the current page. (`[[1]](diffhunk://#diff-e2149e8979998fe75778339f1e0452d39d315200441593c8c1f5ac23b6da3cc5L146-R179)`, `[[2]](diffhunk://#diff-ad0e49ae757bb938550f20f6cc753a5e2f1998572bbd6d22500ae81b60e37f1fL120-R127)`, `[[3]](diffhunk://#diff-ad0e49ae757bb938550f20f6cc753a5e2f1998572bbd6d22500ae81b60e37f1fR433-R435)`)

### New example page for `RfDataGrid`:

* **View Selected Rows**: Introduced a new example page (`ViewSelectedPage.razor`) demonstrating how to toggle between viewing all rows and only selected rows in the data grid. This example highlights the use of the new `Ids` filter property and selection-related enhancements. (`[[1]](diffhunk://#diff-ae61c759a995d08dfe772d162b4dc8690521c620fb91b54998771a3426d3bf39R1-R195)`, `[[2]](diffhunk://#diff-5168fe84d265d1ca97aae734fcd78aea831a24bcdcae440bc04d96b3ea490331R82)`)

+semver: feature