### PR TITLE
Add support for custom HTML attributes in RfDgHeader

### DIFF
--- a/src/RForge/RForgeBlazor/RfDgHeader.razor
+++ b/src/RForge/RForgeBlazor/RfDgHeader.razor
@@ -1,7 +1,7 @@
 @using RForge.Abstractions.DataGrids
 @implements IDisposable
 
-<th @onclick="OnColumnClick" class="@HeaderCss">
+<th @onclick="OnColumnClick" class="@HeaderCss" @attributes="AdditionalAttributes">
     @ChildContent
 
     @if (AllowSorting == true)

--- a/src/RForge/RForgeBlazor/RfDgHeader.razor.cs
+++ b/src/RForge/RForgeBlazor/RfDgHeader.razor.cs
@@ -46,6 +46,16 @@ public partial class RfDgHeader
     /// </summary>
     [Parameter]
     public RenderFragment ChildContent { get; set; }
+
+    /// <summary>
+    /// Gets or sets a collection of additional attributes that do not match any known parameters.
+    /// </summary>
+    /// <remarks>This property is typically used to capture and pass arbitrary HTML attributes or other
+    /// key-value pairs that are not explicitly defined as parameters. The keys in the dictionary represent attribute
+    /// names,  and the values represent their corresponding values.</remarks>
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object> AdditionalAttributes { get; set; }
+
     #endregion
 
     /// <summary>

--- a/src/RForge/RForgeTest/RForgeTest.Client/Pages/DataGrid.razor
+++ b/src/RForge/RForgeTest/RForgeTest.Client/Pages/DataGrid.razor
@@ -20,7 +20,7 @@
             OnLoadData="@LoadData1">
 
     <Headers>
-        <RfDgHeader SortKey="Id">Id</RfDgHeader>
+        <RfDgHeader SortKey="Id" draggable="true">Id</RfDgHeader>
         <RfDgHeader SortKey="FirstName">First Name</RfDgHeader>
         <RfDgHeader SortKey="LastName">Last Name</RfDgHeader>
         <RfDgHeader SortKey="Email">Email</RfDgHeader>


### PR DESCRIPTION
Introduced the `AdditionalAttributes` parameter in the `RfDgHeader` component to allow capturing and rendering arbitrary HTML attributes on the `<th>` element. Updated `RfDgHeader.razor` to include the `@attributes="AdditionalAttributes"` directive and modified the `RfDgHeader` class to support unmatched key-value pairs using `[Parameter(CaptureUnmatchedValues = true)]`.

Demonstrated the new feature in `DataGrid.razor` by adding the `draggable="true"` attribute to the "Id" column header.
+semver:patch