### PR TITLE
Feat/dotnet 10

### DIFF
--- a/.github/workflows/deploy_main.yml
+++ b/.github/workflows/deploy_main.yml
@@ -42,6 +42,7 @@ jobs:
           dotnet-version: |
             8.x
             9.x
+            10.x
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v3.0.0

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -37,6 +37,7 @@ jobs:
           dotnet-version: |
             8.x
             9.x
+            10.x
 
       - name: Build with dotnet
         run: dotnet build --configuration Release

--- a/src/RForge/RForge.Abstractions/RForge.Abstractions.csproj
+++ b/src/RForge/RForge.Abstractions/RForge.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <Description>Placeholder</Description>

--- a/src/RForge/RForge.Blazor.UnitTest/RForge.Blazor.UnitTest.csproj
+++ b/src/RForge/RForge.Blazor.UnitTest/RForge.Blazor.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/src/RForge/RForgeBlazor.Benchmark/RForgeBlazor.Benchmark.csproj
+++ b/src/RForge/RForgeBlazor.Benchmark/RForgeBlazor.Benchmark.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <IsPackable>false</IsPackable>

--- a/src/RForge/RForgeBlazor/RForgeBlazor.csproj
+++ b/src/RForge/RForgeBlazor/RForgeBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <Nullable>disable</Nullable>
         <LangVersion>latest</LangVersion>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/RForge/RForgeBlazor/RfContextMenuLink.razor.cs
+++ b/src/RForge/RForgeBlazor/RfContextMenuLink.razor.cs
@@ -12,6 +12,9 @@ public partial class RfContextMenuLink
     [Parameter]
     public string Href { get; set; }
 
+    /// <summary>
+    /// Gets or sets the URL of the link.
+    /// </summary>
     [Parameter]
     public EventCallback OnClick { get; set; }
 

--- a/src/RForge/RForgeTest/RForgeTest.Client/RForgeTest.Client.csproj
+++ b/src/RForge/RForgeTest/RForgeTest.Client/RForgeTest.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
@@ -16,11 +16,15 @@
     </ItemGroup>
 
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.1" />
-    </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.1" />
+	</ItemGroup>
 
-    <ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
         <ProjectReference Include="..\..\RForgeBlazor\RForgeBlazor.csproj" />
     </ItemGroup>
 

--- a/src/RForge/RForgeTest/RForgeTest/Program.cs
+++ b/src/RForge/RForgeTest/RForgeTest/Program.cs
@@ -6,6 +6,7 @@ using RForgeTest.Components;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents()
     .AddInteractiveWebAssemblyComponents();

--- a/src/RForge/RForgeTest/RForgeTest/RForgeTest.csproj
+++ b/src/RForge/RForgeTest/RForgeTest/RForgeTest.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <Nullable>disable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
@@ -17,8 +17,13 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.1" />
     </ItemGroup>
-    
-    <ItemGroup>
+	
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0" />
+	</ItemGroup>
+
+
+	<ItemGroup>
         <Folder Include="wwwroot\lib\" />
     </ItemGroup>
 


### PR DESCRIPTION
This pull request adds support for .NET 10.0 across the solution. The main changes update all relevant project files and CI workflows to include .NET 10.0 as a target framework, and ensure the correct package versions are used for .NET 10.0 builds. There is also a minor documentation improvement in a component.

**.NET 10.0 Support**

* Updated all project files (`.csproj`) to target `net10.0` in addition to existing frameworks, ensuring the codebase can build and run on .NET 10.0. [[1]](diffhunk://#diff-f5c5483ef1a65dc407a0aa2e38e72e0a73b8493f7f539376c168d8eb4f04caedL4-R4) [[2]](diffhunk://#diff-b6372c5aeb31eb3046238368b28ebd4a19125e8ba5c4ac6a77317f047242bafeL4-R4) [[3]](diffhunk://#diff-a77bbec75c2dba0620f3b67e8d750226f95e5f9ec1838b08537a7c7f39324e7fL5-R5) [[4]](diffhunk://#diff-3699791517d7483c9d79b69d43c83eb0233347dff48e88cbca02f85e8255b733L4-R4) [[5]](diffhunk://#diff-047e55d8cb76d40b7ddc19fa1261edbe2b3ac2accac25aff1ed56a120f01320aL4-R4) [[6]](diffhunk://#diff-83228ce344f2884278257dcc4ec0d3806bd70fa30ae2abe699eadbce269beb80L1-R4)
* Modified GitHub Actions workflow files (`deploy_main.yml`, `deploy_release.yml`) to include `10.x` in the `dotnet-version` matrix, enabling CI/CD for .NET 10.0. [[1]](diffhunk://#diff-ae7edb55cb45a6c39f5457836ed0307a4cbf44691c771539059483da9fa6b24bR45) [[2]](diffhunk://#diff-85bd47dfba9f57975cf6c7c65e1bbc4c709c0f502d319fb5138506f2e7d2c948R40)

**Package Management**

* Added conditional `PackageReference` entries for .NET 10.0 in `RForgeTest.Client.csproj` and `RForgeTest.csproj` to ensure the correct versions of `Microsoft.AspNetCore.Components.WebAssembly` and `Microsoft.AspNetCore.Components.WebAssembly.Server` are used when building for .NET 10.0. [[1]](diffhunk://#diff-047e55d8cb76d40b7ddc19fa1261edbe2b3ac2accac25aff1ed56a120f01320aR23-R26) [[2]](diffhunk://#diff-83228ce344f2884278257dcc4ec0d3806bd70fa30ae2abe699eadbce269beb80R21-R25)

**Other Improvements**

* Added a summary XML documentation comment to the `Href` property in `RfContextMenuLink.razor.cs` for better code clarity.